### PR TITLE
Fix pSEO page rendering

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: page
 title: "Page Not Found"
 description: "The page you're looking for doesn't exist. Head back to PondPilot's homepage."
 permalink: /404.html

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,19 @@
+---
+layout: default
+---
+
+<div class="blog-post-container">
+    <div class="container-narrow">
+        <div class="blog-post-header">
+            <h1>{{ page.title }}</h1>
+        </div>
+        
+        <article class="blog-post-content">
+            {{ content }}
+        </article>
+
+        <div class="blog-nav">
+            <a href="/" class="blog-back-link"><i class="fas fa-arrow-left"></i> Back to home</a>
+        </div>
+    </div>
+</div>

--- a/pseo/air-gapped-data-analysis.md
+++ b/pseo/air-gapped-data-analysis.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Air-Gapped Data Analysis — SQL Without Network Access"
 description: "Run SQL analytics on air-gapped machines. PondPilot works offline as a PWA — no internet, no servers, no data exfiltration risk."
 permalink: /privacy/air-gapped-data-analysis/
 ---
 
-# Air-Gapped Data Analysis
 
 Some environments have no internet access by design. Classified networks, secure facilities, isolated lab machines. PondPilot works on all of them — install it once while online, then use it forever offline.
 

--- a/pseo/analyze-csv-in-browser.md
+++ b/pseo/analyze-csv-in-browser.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Analyze CSV in Browser — No Upload, No Signup"
 description: "Query and analyze CSV files directly in your browser with SQL. No server uploads, no accounts. Powered by DuckDB WASM."
 permalink: /use-cases/analyze-csv-in-browser/
 ---
 
-# Analyze CSV Files in Your Browser with SQL
 
 Drop a CSV file into PondPilot and start writing SQL against it immediately. No uploads to any server. No account creation. No waiting.
 

--- a/pseo/browse-iceberg-tables-online.md
+++ b/pseo/browse-iceberg-tables-online.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Browse Iceberg Tables Online — No Spark, No Trino"
 description: "Explore Apache Iceberg tables from your browser. Connect to REST Catalogs, browse schemas, query data — no infrastructure required."
 permalink: /use-cases/browse-iceberg-tables-online/
 ---
 
-# Browse Iceberg Tables Online
 
 Apache Iceberg tables are everywhere now — but browsing them still feels like it requires a PhD in distributed systems. PondPilot lets you explore Iceberg tables from a browser tab. No Spark session, no Trino cluster, no Docker compose files.
 

--- a/pseo/browser-sql-analytics.md
+++ b/pseo/browser-sql-analytics.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Browser SQL Analytics — Analyze Data Without Installing Anything"
 description: "Run SQL analytics in your browser. Query CSV, Parquet, JSON files with DuckDB. No installation, no cloud, no signup."
 permalink: /use-cases/browser-sql-analytics/
 ---
 
-# Browser SQL Analytics
 
 You shouldn't need to install software to analyze a data file. PondPilot runs a full SQL analytics engine in your browser — open a tab, drop a file, get answers.
 

--- a/pseo/column-level-lineage-tool.md
+++ b/pseo/column-level-lineage-tool.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Column-Level Lineage Tool — Trace SQL Data Flow Precisely"
 description: "Map data flow at the column level in SQL queries. FlowScope provides precise lineage analysis — Rust+WASM, multi-dialect, open source."
 permalink: /tools/column-level-lineage-tool/
 ---
 
-# Column-Level Lineage Tool
 
 Table-level lineage tells you "this query reads from table A and writes to table B." Column-level lineage tells you exactly which columns in B came from which columns in A, and how they were transformed. That precision matters.
 

--- a/pseo/compare-datasets-in-browser.md
+++ b/pseo/compare-datasets-in-browser.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Compare Datasets in Browser — Diff CSV, Parquet, JSON"
 description: "Compare two datasets side by side using SQL in your browser. Find differences, reconcile data, and validate changes without uploading anything."
 permalink: /use-cases/compare-datasets-in-browser/
 ---
 
-# Compare Datasets in Your Browser
 
 Need to diff two CSV exports? Reconcile last month's report against this month's? Validate that a data migration didn't drop rows? PondPilot makes dataset comparison straightforward with SQL.
 

--- a/pseo/convert-data-formats-browser.md
+++ b/pseo/convert-data-formats-browser.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Convert Data Formats in the Browser — CSV, Parquet, JSON, SAS, Stata, SPSS"
 description: "Convert between CSV, Parquet, JSON, Excel, DuckDB, SAS, Stata, and SPSS files entirely in your browser. No uploads, no installs."
 permalink: /formats/convert-data-formats-browser/
 ---
 
-# Convert Data Formats in the Browser
 
 PondPilot is a many-to-many data format converter that runs entirely in your browser. Open a file in any supported format, query or transform it with SQL, and export to any other format. No servers, no uploads, no accounts.
 

--- a/pseo/csv-to-sql-online.md
+++ b/pseo/csv-to-sql-online.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "CSV to SQL Online — Query Spreadsheet Data Instantly"
 description: "Convert CSV files into queryable SQL tables in your browser. No upload, no conversion step — just drop and query."
 permalink: /use-cases/csv-to-sql-online/
 ---
 
-# CSV to SQL Online
 
 You have a CSV. You want to query it with SQL. PondPilot skips the conversion step — drop a CSV file and it's immediately a SQL table.
 

--- a/pseo/data-analysis-for-startups.md
+++ b/pseo/data-analysis-for-startups.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Data Analysis for Startups — Free SQL Tool, No Infrastructure"
 description: "Analyze your startup's data without paying for analytics tools. PondPilot is free, runs in your browser, and needs zero infrastructure."
 permalink: /audience/data-analysis-for-startups/
 ---
 
-# Data Analysis for Startups
 
 Early-stage startups don't need a $50K/year analytics platform. You need to query CSVs from Stripe, your CRM, and your product database. PondPilot does that for free, in your browser, with zero infrastructure.
 

--- a/pseo/data-analysis-without-uploading.md
+++ b/pseo/data-analysis-without-uploading.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Data Analysis Without Uploading — 100% Client-Side"
 description: "Analyze data without uploading it anywhere. PondPilot runs SQL entirely in your browser. Zero servers, zero data collection."
 permalink: /privacy/data-analysis-without-uploading/
 ---
 
-# Data Analysis Without Uploading
 
 Every cloud analytics tool has the same ask: upload your data to our servers. PondPilot takes a different approach — your data never leaves your browser.
 

--- a/pseo/data-format-converter-browser.md
+++ b/pseo/data-format-converter-browser.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Browser Data Format Converter — CSV, Parquet, JSON, Excel, SAS, Stata, SPSS"
 description: "Convert between data formats in your browser. Supports CSV, Parquet, JSON, Excel, DuckDB, SAS, Stata, and SPSS. Free, private, open source."
 permalink: /formats/data-format-converter-browser/
 ---
 
-# Data Format Converter — In Your Browser
 
 PondPilot is the Swiss Army knife of data format conversion. Open a file in any supported format, optionally transform it with SQL, and export to any other format. It runs entirely in your browser — no uploads, no accounts, no servers.
 

--- a/pseo/data-quality-check-tool.md
+++ b/pseo/data-quality-check-tool.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Data Quality Check Tool — Validate Data with SQL"
 description: "Run data quality checks on CSV and Parquet files using SQL. Find nulls, duplicates, outliers, and schema issues in your browser."
 permalink: /tools/data-quality-check-tool/
 ---
 
-# Data Quality Check Tool
 
 Before you trust a dataset, you need to check it. PondPilot lets you run data quality checks with SQL — find nulls, duplicates, type mismatches, and outliers without uploading data anywhere.
 

--- a/pseo/data-tools-for-journalists.md
+++ b/pseo/data-tools-for-journalists.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Data Tools for Journalists — Investigate Data Privately"
 description: "Analyze datasets for investigations without uploading to cloud services. PondPilot runs SQL in your browser — source protection built in."
 permalink: /audience/data-tools-for-journalists/
 ---
 
-# Data Tools for Journalists
 
 Investigative journalism runs on data. Public records, leaked documents, FOI responses — they all need analysis. But uploading sensitive datasets to cloud tools puts sources at risk. PondPilot keeps your analysis local.
 

--- a/pseo/datasette-alternative.md
+++ b/pseo/datasette-alternative.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Datasette Alternative — Client-Side Data Exploration"
 description: "Looking for a Datasette alternative? PondPilot offers browser-based SQL exploration with zero server setup. No Python, no deployment."
 permalink: /alternatives/datasette-alternative/
 ---
 
-# Datasette Alternative
 
 [Datasette](https://datasette.io/) is a great tool for publishing and exploring SQLite databases. But it requires Python, a server process, and deployment if you want to share. PondPilot takes a different approach: everything runs in your browser.
 

--- a/pseo/db-fiddle-alternative.md
+++ b/pseo/db-fiddle-alternative.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "DB Fiddle Alternative — SQL Playground Without Server"
 description: "A DB Fiddle alternative that runs entirely in your browser. No shared server, no query limits. Query your own files with DuckDB SQL."
 permalink: /alternatives/db-fiddle-alternative/
 ---
 
-# DB Fiddle Alternative
 
 [DB Fiddle](https://www.db-fiddle.com/) is useful for testing SQL snippets online. But it runs queries on a shared server, supports limited databases, and you can't bring your own data. PondPilot is a different kind of SQL playground.
 

--- a/pseo/duckdb-browser-tool.md
+++ b/pseo/duckdb-browser-tool.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "DuckDB Browser Tool — Run DuckDB in Your Browser"
 description: "Use DuckDB directly in your browser. Query CSV, Parquet, JSON files with SQL. No installation, powered by DuckDB WASM."
 permalink: /duckdb/browser-tool/
 ---
 
-# DuckDB Browser Tool
 
 DuckDB is a fast, embeddable analytical database. PondPilot puts it in your browser — no installation, no terminal, no Python. Just open a tab and start querying.
 

--- a/pseo/duckdb-csv-query.md
+++ b/pseo/duckdb-csv-query.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "DuckDB CSV Query — Query CSV Files with DuckDB SQL"
 description: "Use DuckDB's SQL to query CSV files directly in your browser. Auto-detection, fast parsing, and full analytical SQL."
 permalink: /duckdb/csv-query/
 ---
 
-# Query CSV Files with DuckDB
 
 DuckDB's CSV reader is exceptional — it auto-detects delimiters, headers, and types, then lets you query the file with full analytical SQL. PondPilot brings this to your browser with zero setup.
 

--- a/pseo/duckdb-iceberg-wasm.md
+++ b/pseo/duckdb-iceberg-wasm.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "DuckDB + Iceberg + WASM — Query Iceberg Tables from the Browser"
 description: "The DuckDB Iceberg extension now works in WebAssembly. PondPilot puts it in a real SQL editor you can use today."
 permalink: /use-cases/duckdb-iceberg-wasm/
 ---
 
-# DuckDB + Iceberg + WASM
 
 DuckDB's Iceberg extension [now runs in WebAssembly](https://duckdb.org/2025/12/16/iceberg-in-the-browser). This means a browser can connect to an Iceberg REST Catalog, resolve table metadata, and query Parquet data files — all without a server. PondPilot wraps this capability in a proper SQL editor with a real UI.
 

--- a/pseo/duckdb-json-query.md
+++ b/pseo/duckdb-json-query.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "DuckDB JSON Query — Query JSON with SQL in Browser"
 description: "Query JSON files with DuckDB SQL in your browser. Flatten nested data, filter arrays, join with CSV. No server, no upload."
 permalink: /duckdb/json-query/
 ---
 
-# Query JSON Files with DuckDB
 
 JSON is everywhere — API responses, log files, NoSQL exports. DuckDB's JSON support is best-in-class, and PondPilot puts it in your browser.
 

--- a/pseo/duckdb-online-playground.md
+++ b/pseo/duckdb-online-playground.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "DuckDB Online Playground — Try DuckDB Instantly"
 description: "Try DuckDB SQL in your browser without installing anything. Load your own data, write queries, see results. Free and open source."
 permalink: /duckdb/online-playground/
 ---
 
-# DuckDB Online Playground
 
 Want to try DuckDB without installing it? PondPilot is a polished, browser-based DuckDB playground where you can write SQL against your own data — instantly.
 

--- a/pseo/duckdb-parquet-viewer.md
+++ b/pseo/duckdb-parquet-viewer.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "DuckDB Parquet Viewer — Browse and Query Parquet Files"
 description: "View and query Apache Parquet files using DuckDB in your browser. Schema inspection, predicate pushdown, zero installation."
 permalink: /duckdb/parquet-viewer/
 ---
 
-# DuckDB Parquet Viewer
 
 Parquet files are binary — you can't just open them in a text editor. PondPilot uses DuckDB WASM to let you browse, inspect, and query Parquet files directly in your browser.
 

--- a/pseo/duckdb-wasm-sql-editor.md
+++ b/pseo/duckdb-wasm-sql-editor.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "DuckDB WASM SQL Editor — Full SQL in the Browser"
 description: "A polished SQL editor powered by DuckDB WASM. Syntax highlighting, autocomplete, multi-file support. Runs entirely client-side."
 permalink: /duckdb/wasm-sql-editor/
 ---
 
-# DuckDB WASM SQL Editor
 
 DuckDB WASM is powerful, but using it raw means writing JavaScript glue code. PondPilot wraps it in a proper SQL editor with everything you'd expect from a desktop tool — running entirely in your browser.
 

--- a/pseo/embed-sql-in-documentation.md
+++ b/pseo/embed-sql-in-documentation.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Embed SQL in Documentation — Interactive, Runnable Queries"
 description: "Add interactive SQL to your docs and blog posts. Readers run and modify queries in-browser. No backend, no API keys."
 permalink: /tools/embed-sql-in-documentation/
 ---
 
-# Embed SQL in Documentation
 
 Static code blocks show SQL. Interactive embeds let readers *run* SQL. PondPilot Widget turns your documentation into a hands-on learning experience.
 

--- a/pseo/excel-alternative-data-analysis.md
+++ b/pseo/excel-alternative-data-analysis.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Excel Alternative for Data Analysis — SQL Beats Spreadsheets"
 description: "Analyze large datasets without Excel's limitations. PondPilot lets you use SQL on CSV files in your browser — faster, more powerful, free."
 permalink: /alternatives/excel-alternative-for-data-analysis/
 ---
 
-# Excel Alternative for Data Analysis
 
 Excel is great for small datasets and quick formatting. But when you're analyzing thousands (or millions) of rows, it falls apart. PondPilot lets you use SQL instead — faster, more powerful, and it runs in your browser.
 

--- a/pseo/excel-to-parquet-converter.md
+++ b/pseo/excel-to-parquet-converter.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Convert Excel to Parquet Online — Free, In-Browser"
 description: "Convert Excel .xlsx files to Parquet directly in the browser. No uploads, no installs. Clean data with SQL before exporting."
 permalink: /formats/excel-to-parquet-converter/
 ---
 
-# Excel to Parquet Converter
 
 Excel is where data goes to lose its types. Dates become numbers, integers become floats, and "TRUE" becomes a string. Converting to Parquet fixes all of that — and PondPilot lets you do it in the browser with SQL-powered transformations.
 

--- a/pseo/explore-json-data-locally.md
+++ b/pseo/explore-json-data-locally.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Explore JSON Data Locally with SQL"
 description: "Query JSON files with SQL in your browser. Flatten nested structures, filter arrays, and export results. No server, no uploads."
 permalink: /use-cases/explore-json-data-locally/
 ---
 
-# Explore JSON Data Locally with SQL
 
 API responses, log files, config exports — JSON is everywhere. But exploring nested JSON in a text editor is tedious. PondPilot lets you query JSON files with SQL, locally in your browser.
 

--- a/pseo/gdpr-compliant-data-tool.md
+++ b/pseo/gdpr-compliant-data-tool.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "GDPR Compliant Data Tool — No Data Processing Agreements Needed"
 description: "Analyze data without GDPR concerns. PondPilot processes everything client-side — no data leaves your browser, no DPA required."
 permalink: /privacy/gdpr-compliant-data-tool/
 ---
 
-# GDPR Compliant Data Analysis
 
 Most analytics tools require a Data Processing Agreement because they process your data on their servers. PondPilot doesn't process your data at all — your browser does.
 

--- a/pseo/google-sheets-alternative-private.md
+++ b/pseo/google-sheets-alternative-private.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Private Google Sheets Alternative — No Cloud, No Google"
 description: "Analyze spreadsheet data without Google. PondPilot processes CSV files locally in your browser with SQL. No uploads, no Google account."
 permalink: /alternatives/google-sheets-alternative-private/
 ---
 
-# Private Google Sheets Alternative
 
 Google Sheets is convenient. It's also a Google product that stores your data on Google's servers, scans it for features, and requires a Google account. If you want spreadsheet-style data analysis without the Google dependency, PondPilot is an option.
 

--- a/pseo/iceberg-browser-client.md
+++ b/pseo/iceberg-browser-client.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Iceberg Browser Client — Query Iceberg Catalogs from Your Browser"
 description: "Connect to Iceberg REST Catalogs directly from your browser with PondPilot. No infrastructure, no JVM, no Spark cluster. Powered by DuckDB WASM."
 permalink: /use-cases/iceberg-browser-client/
 ---
 
-# Iceberg Browser Client
 
 What if you could browse and query your Iceberg tables from a browser tab? No Spark cluster, no Trino deployment, no JVM. Just open PondPilot, point it at your Iceberg REST Catalog, and start running SQL.
 

--- a/pseo/iceberg-data-exploration-tool.md
+++ b/pseo/iceberg-data-exploration-tool.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Iceberg Data Exploration Tool — SQL in the Browser"
 description: "Explore Apache Iceberg data with SQL directly in your browser. No infrastructure, no JVM, no setup. Powered by DuckDB WASM."
 permalink: /use-cases/iceberg-data-exploration-tool/
 ---
 
-# Iceberg Data Exploration Tool
 
 Exploration is how you build intuition about data. But with Iceberg, exploration has traditionally required the same heavy infrastructure as production queries. PondPilot changes that — connect to an Iceberg REST Catalog from your browser and start exploring immediately.
 

--- a/pseo/iceberg-rest-catalog-viewer.md
+++ b/pseo/iceberg-rest-catalog-viewer.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Iceberg REST Catalog Viewer — Browse Tables in Your Browser"
 description: "Browse and explore Iceberg REST Catalog tables from your browser. See schemas, partitions, and snapshots without Spark or Trino."
 permalink: /use-cases/iceberg-rest-catalog-viewer/
 ---
 
-# Iceberg REST Catalog Viewer
 
 You have an Iceberg REST Catalog. You want to see what's in it — namespaces, tables, schemas, partitions. Normally that means firing up Spark, Trino, or at least a Python notebook with pyiceberg. PondPilot lets you browse it all from a browser tab.
 

--- a/pseo/interactive-sql-blog-widget.md
+++ b/pseo/interactive-sql-blog-widget.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Interactive SQL Blog Widget — Let Readers Run Queries"
 description: "Embed interactive SQL in your blog posts. Readers edit and execute queries in-browser. Powered by DuckDB WASM, no server needed."
 permalink: /tools/interactive-sql-blog-widget/
 ---
 
-# Interactive SQL Blog Widget
 
 Writing a blog post about data analysis? Don't just show the SQL — let readers run it. PondPilot Widget embeds a live SQL editor that turns passive readers into active explorers.
 

--- a/pseo/interactive-sql-tutorial-embed.md
+++ b/pseo/interactive-sql-tutorial-embed.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Interactive SQL Tutorial Embed — Runnable Examples"
 description: "Embed interactive SQL tutorials in your website. Readers edit and run queries in-browser. No server needed."
 permalink: /use-cases/interactive-sql-tutorial-embed/
 ---
 
-# Embed Interactive SQL Tutorials
 
 Teaching SQL with static code blocks is like teaching driving with a textbook. PondPilot Widget lets you embed interactive, runnable SQL examples that students can modify and experiment with.
 

--- a/pseo/json-to-csv-converter.md
+++ b/pseo/json-to-csv-converter.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Convert JSON to CSV Online — Query First, Then Export"
 description: "Convert JSON files to CSV in the browser with SQL transformations. Flatten nested objects, filter rows, select fields. No uploads."
 permalink: /formats/json-to-csv-converter/
 ---
 
-# JSON to CSV Converter
 
 JSON is great for APIs and developers. CSV is great for spreadsheets and non-technical stakeholders. PondPilot bridges the two — with SQL in between so you can flatten, filter, and reshape before exporting.
 

--- a/pseo/jupyter-notebook-alternative-sql.md
+++ b/pseo/jupyter-notebook-alternative-sql.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Jupyter Notebook Alternative for SQL — No Setup, No Kernels"
 description: "Run SQL without Jupyter's complexity. PondPilot is a browser-based SQL environment — no Python, no kernels, no package management."
 permalink: /alternatives/jupyter-notebook-alternative-for-sql/
 ---
 
-# Jupyter Notebook Alternative for SQL
 
 If you're using Jupyter just to run SQL queries against data files, you're maintaining a Python environment, managing kernels, and installing packages for something that should be simpler. PondPilot gives you SQL on files without any of that.
 

--- a/pseo/local-data-analysis-tool.md
+++ b/pseo/local-data-analysis-tool.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Local Data Analysis Tool — Everything Runs on Your Machine"
 description: "Analyze data locally without cloud dependencies. PondPilot runs SQL in your browser, processes files on your machine, stores nothing remotely."
 permalink: /privacy/local-data-analysis-tool/
 ---
 
-# Local Data Analysis Tool
 
 "Local" means something specific: your data is processed on your machine, stored on your machine, and never transmitted anywhere else. PondPilot is local in the strictest sense.
 

--- a/pseo/mode-analytics-alternative.md
+++ b/pseo/mode-analytics-alternative.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Free Mode Analytics Alternative — SQL Analytics Without the SaaS"
 description: "A free, private alternative to Mode Analytics. Run SQL against local files in your browser. No cloud, no subscription, no data uploads."
 permalink: /alternatives/mode-analytics-alternative/
 ---
 
-# Free Mode Analytics Alternative
 
 Mode Analytics is a collaborative SQL analytics platform. It's also a SaaS product that requires uploading your data, managing connections, and paying per seat. PondPilot gives you SQL analytics for free — in your browser, on your data, with zero cloud dependency.
 

--- a/pseo/no-cloud-sql-editor.md
+++ b/pseo/no-cloud-sql-editor.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "No-Cloud SQL Editor — Run Queries Without a Server"
 description: "A SQL editor that runs entirely in your browser. No cloud infrastructure, no data uploads, no account. DuckDB WASM powered."
 permalink: /privacy/no-cloud-sql-editor/
 ---
 
-# No-Cloud SQL Editor
 
 Cloud SQL editors are convenient until you think about where your data goes. PondPilot gives you the same convenience with none of the cloud: queries run in your browser, data stays on your machine.
 

--- a/pseo/offline-data-analysis-tool.md
+++ b/pseo/offline-data-analysis-tool.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Offline Data Analysis Tool — SQL Without Internet"
 description: "Analyze CSV, Parquet, and JSON files with SQL offline. PondPilot works as a PWA — install once, use anywhere, no internet needed."
 permalink: /privacy/offline-data-analysis-tool/
 ---
 
-# Offline Data Analysis Tool
 
 PondPilot works without an internet connection. Install it as a Progressive Web App, go offline, and analyze your data with full SQL support.
 

--- a/pseo/open-sas-files-in-browser.md
+++ b/pseo/open-sas-files-in-browser.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Open SAS Files in Your Browser — No SAS License Needed"
 description: "View and query SAS .sas7bdat files directly in your browser with PondPilot. No SAS license, no uploads, no installs. Your data stays local."
 permalink: /formats/open-sas-files-in-browser/
 ---
 
-# Open SAS Files in Your Browser
 
 SAS licenses cost tens of thousands of dollars per year. But maybe you just need to look at a `.sas7bdat` file someone sent you. Maybe you need to run a quick query, check row counts, or export it to CSV. You shouldn't need a five-figure license for that.
 

--- a/pseo/open-source-sql-editor.md
+++ b/pseo/open-source-sql-editor.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Open Source SQL Editor — Free, Transparent, Community-Driven"
 description: "A fully open source SQL editor that runs in your browser. Inspect the code, contribute, or self-host. Powered by DuckDB WASM."
 permalink: /use-cases/open-source-sql-editor/
 ---
 
-# Open Source SQL Editor
 
 PondPilot is fully open source under a permissive license. Every line of code is on [GitHub](https://github.com/pondpilot). No proprietary backend, no hidden telemetry, no "open core" bait-and-switch.
 

--- a/pseo/open-spss-files-in-browser.md
+++ b/pseo/open-spss-files-in-browser.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Open SPSS .sav Files in Your Browser — No SPSS License Needed"
 description: "View and query SPSS .sav files in the browser with PondPilot. No IBM SPSS license, no uploads, no servers. Data stays local."
 permalink: /formats/open-spss-files-in-browser/
 ---
 
-# Open SPSS Files in Your Browser
 
 IBM SPSS Statistics starts at over $1,000/year. If someone sent you an `.sav` file and you just need to see what's in it, that's an expensive peek. PondPilot opens SPSS `.sav` files directly in the browser — for free, with no software to install.
 

--- a/pseo/open-stata-files-in-browser.md
+++ b/pseo/open-stata-files-in-browser.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Open Stata .dta Files in Your Browser — Free, No License"
 description: "View and query Stata .dta files directly in the browser with PondPilot. No Stata license required. Data stays on your machine."
 permalink: /formats/open-stata-files-in-browser/
 ---
 
-# Open Stata Files in Your Browser
 
 Got a `.dta` file but no Stata license? You're not alone. Stata is standard in economics and social science research, but the software costs hundreds to thousands of dollars. Sometimes you just need to inspect a dataset a colleague shared.
 

--- a/pseo/parquet-to-csv-converter.md
+++ b/pseo/parquet-to-csv-converter.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Parquet to CSV Converter — Convert in Browser with SQL"
 description: "Convert Parquet files to CSV in your browser. Filter, transform, and export with SQL. No upload, no Python, no command line."
 permalink: /use-cases/parquet-to-csv-converter/
 ---
 
-# Parquet to CSV Converter
 
 Need to convert a Parquet file to CSV? PondPilot does it in your browser — and unlike simple converters, you can filter and transform the data with SQL before exporting.
 

--- a/pseo/parquet-viewer-online.md
+++ b/pseo/parquet-viewer-online.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Parquet Viewer Online — Browse and Query Parquet Files in the Browser"
 description: "View Parquet files online with PondPilot. Browse schemas, preview data, run SQL queries, and export results. No uploads, no installs."
 permalink: /formats/parquet-viewer-online/
 ---
 
-# Parquet Viewer Online
 
 Parquet files are great for storage and performance. They're terrible for quick inspection — you can't just open them in a text editor. PondPilot gives you a fast, browser-based Parquet viewer with full SQL support.
 

--- a/pseo/personal-finance-data-analysis.md
+++ b/pseo/personal-finance-data-analysis.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Personal Finance Data Analysis — Private, Local, Free"
 description: "Analyze your bank statements and financial data with SQL in your browser. Your money data never leaves your machine."
 permalink: /use-cases/personal-finance-data-analysis/
 ---
 
-# Personal Finance Data Analysis Tool
 
 Your bank lets you export transactions as CSV. Most analysis tools want you to upload that file to their servers. PondPilot doesn't — your financial data stays on your machine, period.
 

--- a/pseo/private-data-exploration.md
+++ b/pseo/private-data-exploration.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Private Data Exploration — Analyze Sensitive Data Locally"
 description: "Explore sensitive datasets without exposing them to cloud services. PondPilot runs SQL in your browser — zero data leaves your machine."
 permalink: /privacy/private-data-exploration/
 ---
 
-# Private Data Exploration
 
 Some data shouldn't touch the cloud. Medical records, financial statements, employee data, customer PII — you need to analyze it, but you also need it to stay private. PondPilot lets you explore data with SQL while keeping everything local.
 

--- a/pseo/query-parquet-files-online.md
+++ b/pseo/query-parquet-files-online.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Query Parquet Files Online — Browser-Based SQL"
 description: "Open and query Apache Parquet files in your browser with SQL. No Python, no Spark, no server. DuckDB WASM powered."
 permalink: /use-cases/query-parquet-files-online/
 ---
 
-# Query Parquet Files Online
 
 Parquet is the go-to columnar format for analytics, but querying it usually means spinning up Python, Spark, or a database. PondPilot lets you query Parquet files directly in your browser with SQL.
 

--- a/pseo/sas-file-viewer-free.md
+++ b/pseo/sas-file-viewer-free.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Free SAS File Viewer — Open .sas7bdat Without SAS"
 description: "View SAS .sas7bdat files for free in your browser. No SAS license, no installation, no data uploads. Query with SQL, export to CSV or Parquet."
 permalink: /formats/sas-file-viewer-free/
 ---
 
-# Free SAS File Viewer
 
 Looking for a way to open `.sas7bdat` files without paying for SAS? PondPilot is a free, browser-based SAS file viewer that lets you inspect, query, and export SAS datasets. No license, no installation, no data uploads.
 

--- a/pseo/sas-to-csv-converter.md
+++ b/pseo/sas-to-csv-converter.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Convert SAS to CSV Online — Free, No SAS License"
 description: "Convert .sas7bdat files to CSV directly in your browser. No SAS license, no uploads, no installs. Powered by DuckDB WebAssembly."
 permalink: /formats/sas-to-csv-converter/
 ---
 
-# SAS to CSV Converter
 
 Need to get data out of a `.sas7bdat` file and into CSV? PondPilot converts SAS files to CSV entirely in your browser. No SAS license. No Python environment. No uploading files to some random website.
 

--- a/pseo/sas-to-parquet-converter.md
+++ b/pseo/sas-to-parquet-converter.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Convert SAS to Parquet Online — Modernize Legacy Data"
 description: "Convert .sas7bdat files to Parquet in the browser. No SAS license, no servers. Migrate legacy SAS data to a modern columnar format."
 permalink: /formats/sas-to-parquet-converter/
 ---
 
-# SAS to Parquet Converter
 
 Parquet is the standard for modern data infrastructure. SAS `.sas7bdat` is a legacy format tied to expensive proprietary software. PondPilot bridges the gap — convert SAS files to Parquet directly in your browser, no license required.
 

--- a/pseo/spss-to-csv-converter.md
+++ b/pseo/spss-to-csv-converter.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Convert SPSS .sav to CSV Online — Free, No License"
 description: "Convert SPSS .sav files to CSV directly in the browser. No IBM SPSS license. No data uploads. Runs locally via DuckDB WebAssembly."
 permalink: /formats/spss-to-csv-converter/
 ---
 
-# SPSS to CSV Converter
 
 IBM SPSS is expensive and you probably don't need a full license just to convert a `.sav` file to CSV. PondPilot does it in the browser — free, private, instant.
 

--- a/pseo/sql-data-cleaning-tool.md
+++ b/pseo/sql-data-cleaning-tool.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "SQL Data Cleaning Tool — Clean Messy Data in Your Browser"
 description: "Clean and transform messy CSV data with SQL. Remove duplicates, fix formats, filter junk — all in your browser, no uploads."
 permalink: /use-cases/sql-data-cleaning-tool/
 ---
 
-# SQL Data Cleaning Tool
 
 Messy data is the norm. Duplicate rows, inconsistent formats, null values, junk entries. PondPilot lets you clean data with SQL — a more powerful and reproducible approach than manual spreadsheet editing.
 

--- a/pseo/sql-editor-for-documentation.md
+++ b/pseo/sql-editor-for-documentation.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "SQL Editor for Documentation — Embed Interactive Queries"
 description: "Embed a live SQL editor in your docs, blog, or tutorial. Readers run queries in-browser. No backend required."
 permalink: /use-cases/sql-editor-for-documentation/
 ---
 
-# SQL Editor for Documentation
 
 Static SQL code blocks in docs are fine until your reader wants to tweak a query. PondPilot Widget lets you embed a live, interactive SQL editor that readers can actually run.
 

--- a/pseo/sql-explorer-for-students.md
+++ b/pseo/sql-explorer-for-students.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "SQL Explorer for Students — Learn SQL Free, No Setup"
 description: "Practice SQL with your own data in the browser. No database installation, no signup. Perfect for students learning data analysis."
 permalink: /audience/sql-explorer-for-students/
 ---
 
-# SQL Explorer for Students
 
 Learning SQL shouldn't require setting up PostgreSQL, configuring Docker, or paying for a cloud database. PondPilot gives you a SQL environment in your browser — bring your own data and start practicing.
 

--- a/pseo/sql-lineage-visualization.md
+++ b/pseo/sql-lineage-visualization.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "SQL Lineage Visualization — Trace Data Flow in SQL"
 description: "Visualize SQL data lineage at the column level. FlowScope parses SQL and maps data flow — open source, multi-dialect, Rust+WASM."
 permalink: /tools/sql-lineage-visualization/
 ---
 
-# SQL Lineage Visualization
 
 Understanding how data flows through SQL transformations is critical for debugging, auditing, and refactoring pipelines. FlowScope, part of the PondPilot family, gives you column-level SQL lineage visualization.
 

--- a/pseo/sql-playground-no-signup.md
+++ b/pseo/sql-playground-no-signup.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "SQL Playground — No Signup, No Account Required"
 description: "Practice SQL instantly in your browser. No signup, no email, no account. Write queries against your own data or built-in examples."
 permalink: /use-cases/sql-playground-no-signup/
 ---
 
-# SQL Playground — No Signup Required
 
 Every SQL playground on the internet wants your email. PondPilot doesn't. Open the app, write SQL, get results.
 

--- a/pseo/sql-tool-for-product-managers.md
+++ b/pseo/sql-tool-for-product-managers.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "SQL Tool for Product Managers — Query Data Without Engineering"
 description: "Analyze product data with SQL without bothering your data team. PondPilot runs in your browser on CSV exports — no database access needed."
 permalink: /audience/sql-tool-for-product-managers/
 ---
 
-# SQL Tool for Product Managers
 
 You have a CSV export from your analytics tool. You want to slice the data a way the dashboard doesn't support. Your options: wait for the data team, fumble with Excel pivot tables, or learn enough SQL to answer your own questions. PondPilot makes option three easy.
 

--- a/pseo/stata-to-csv-converter.md
+++ b/pseo/stata-to-csv-converter.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Convert Stata .dta to CSV Online — Free, No License"
 description: "Convert Stata .dta files to CSV in the browser. No Stata license needed. Data stays on your machine. Powered by DuckDB WASM."
 permalink: /formats/stata-to-csv-converter/
 ---
 
-# Stata to CSV Converter
 
 Someone sent you a `.dta` file and you need it in CSV. You don't have Stata, and you don't want to install Python just for this. PondPilot converts Stata files to CSV in your browser — zero setup, zero cost.
 

--- a/pseo/statistical-data-format-converter.md
+++ b/pseo/statistical-data-format-converter.md
@@ -1,11 +1,10 @@
 ---
-layout: default
+layout: page
 title: "Statistical Data Format Converter — SAS, Stata, SPSS to CSV/Parquet"
 description: "Convert between SAS, Stata, SPSS, CSV, Parquet, and more in the browser. No licenses, no uploads. Open source and privacy-first."
 permalink: /formats/statistical-data-format-converter/
 ---
 
-# Statistical Data Format Converter
 
 SAS, Stata, and SPSS have been the backbone of academic and government research for decades. But their file formats are proprietary, and the licenses are expensive. PondPilot reads all three — and converts them to modern, open formats — entirely in your browser.
 


### PR DESCRIPTION
pSEO pages were rendering raw content into `<main>` without any container or styling — no max-width, no padding, ugly.

**Fix:**
- Created `_layouts/page.html` — reuses the blog post container/narrow styling (container-narrow + blog-post-content) for proper typography and width
- Switched all 60 pSEO pages + 404 from `layout: default` to `layout: page`
- Removed duplicate H1 from page content (layout now renders `page.title` as H1)