### PR TITLE
Add 31 pSEO pages (formats, Sonar/Quack/FlowScope, alternatives, audiences, privacy)

### DIFF
--- a/pseo/arrow-feather-viewer.md
+++ b/pseo/arrow-feather-viewer.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: "Arrow / Feather Viewer — Open .arrow and .feather Files in Browser"
+description: "Open Arrow and Feather files in your browser via DuckDB. Zero-copy reads, full SQL, no uploads."
+permalink: /formats/arrow-feather-viewer/
+---
+
+
+Arrow and Feather files are everywhere in the modern data stack — fast, columnar, language-neutral. They're also annoying to inspect without booting up Python or R. PondPilot opens `.arrow` and `.feather` files directly in your browser.
+
+## Open Any Arrow or Feather File
+
+1. Open [app.pondpilot.io](https://app.pondpilot.io)
+2. Drop in your `.arrow` or `.feather` file
+3. Instantly see the schema and a data preview
+4. Query with SQL
+
+The file is read in place via DuckDB WebAssembly. No conversion, no import step, no upload.
+
+## Zero-Copy, Fast
+
+Arrow's whole point is zero-copy columnar data. DuckDB speaks Arrow natively, which means reads are efficient — the engine and the file format share the same memory layout. Large Arrow files open quickly because DuckDB only materializes the columns your query touches.
+
+## Full SQL on Top
+
+Most Arrow viewers show you a table and stop there. PondPilot gives you DuckDB's full analytical SQL:
+
+```sql
+SELECT
+  date_trunc('day', event_ts) AS day,
+  event_type,
+  COUNT(*) AS n
+FROM 'events.arrow'
+GROUP BY 1, 2
+ORDER BY 1 DESC, n DESC;
+```
+
+Aggregations, joins across files, window functions — all the things a plain viewer can't do.
+
+## Feather v1 and v2
+
+Feather started as a simple on-disk Arrow format and evolved into Feather v2 (essentially Arrow IPC). PondPilot handles both. If the file opens in PyArrow or R's `arrow` package, it opens here.
+
+## Schema Inspection
+
+Arrow files carry full type information — nested structs, lists, dictionaries, extension types. The schema panel shows all of it, which is invaluable when you receive a file and need to understand its shape before writing queries.
+
+## Export to Other Formats
+
+View Arrow, export Parquet, CSV, JSON, or Excel. Handy for sharing a slice with someone who doesn't live in the Arrow ecosystem.
+
+## Privacy
+
+Arrow files are often intermediate artifacts in data pipelines — they can contain anything. PondPilot processes everything in-browser. No server sees your file.
+
+## Get Started
+
+Visit [app.pondpilot.io](https://app.pondpilot.io) and open your Arrow or Feather file.
+
+---
+
+## Related
+
+- [Parquet Viewer Online](/formats/parquet-viewer-online/)
+- [Data Format Converter](/formats/data-format-converter-browser/)
+- [DuckDB Browser Tool](/duckdb/browser-tool/)

--- a/pseo/bank-statement-analysis.md
+++ b/pseo/bank-statement-analysis.md
@@ -1,0 +1,87 @@
+---
+layout: page
+title: "Bank Statement Analysis — Categorize and Total Transactions Locally"
+description: "Analyze personal or business bank CSV exports with SQL in your browser. Categorize transactions, compute monthly totals, flag outliers — all private."
+permalink: /use-cases/bank-statement-analysis/
+---
+
+
+Your bank gives you a CSV export. Your accountant wants monthly totals. Your budget app wants you to hand over credentials to a service you've never heard of. PondPilot is a third option: SQL on the file, in your browser, no upload.
+
+## Don't Upload Bank Data to Random Sites
+
+This is the core pitch. Bank transaction history reveals where you live, where you shop, who you pay, and what you earn. Uploading that to a free web tool — or pasting it into a chatbot — is a bad trade for "quick analysis". PondPilot runs DuckDB in WebAssembly inside your browser tab. The CSV doesn't leave your machine.
+
+## Monthly Income and Spending
+
+```sql
+SELECT
+  strftime(date, '%Y-%m') as month,
+  SUM(CASE WHEN amount < 0 THEN -amount ELSE 0 END) as spending,
+  SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END) as income,
+  SUM(amount) as net
+FROM transactions.csv
+GROUP BY month
+ORDER BY month;
+```
+
+Drop your export into [PondPilot](https://app.pondpilot.io) and you have a twelve-month cash-flow table in one query.
+
+## Categorize Transactions
+
+No proprietary "AI categorization" — just SQL patterns you control:
+
+```sql
+SELECT
+  date,
+  amount,
+  description,
+  CASE
+    WHEN description ILIKE '%whole foods%' OR description ILIKE '%trader joe%' THEN 'Groceries'
+    WHEN description ILIKE '%uber%' OR description ILIKE '%lyft%' THEN 'Transport'
+    WHEN description ILIKE '%aws%' OR description ILIKE '%stripe%' THEN 'Business'
+    WHEN description ILIKE '%rent%' OR description ILIKE '%mortgage%' THEN 'Housing'
+    ELSE 'Other'
+  END as category
+FROM transactions.csv;
+```
+
+Tweak the rules, re-run, done. Save the query to reuse next month.
+
+## Flag Outliers
+
+Useful for small-business accounts or catching fraud on a personal card:
+
+```sql
+WITH stats AS (
+  SELECT AVG(amount) as mean_amt, STDDEV(amount) as std_amt
+  FROM transactions.csv WHERE amount < 0
+)
+SELECT t.*
+FROM transactions.csv t, stats
+WHERE t.amount < 0
+  AND ABS(t.amount - stats.mean_amt) > 3 * stats.std_amt
+ORDER BY t.amount;
+```
+
+Anything more than three standard deviations from your average outflow surfaces immediately.
+
+## Combine Accounts
+
+Export CSVs from multiple banks or cards. Open them together in one PondPilot session, `UNION ALL` the relevant columns, and analyze total household or business cash flow across accounts.
+
+## Works Offline
+
+Install PondPilot as a PWA once, then use it without a network connection. Analyze finances on a flight or on a coffee-shop Wi-Fi you don't trust.
+
+## Start Analyzing
+
+[Open PondPilot](https://app.pondpilot.io). Free, open source, no signup, no data collection.
+
+---
+
+## Related
+
+- [Personal Finance Data Analysis](/use-cases/personal-finance-data-analysis/)
+- [Analyze CSV in Browser](/use-cases/analyze-csv-in-browser/)
+- [Private Data Exploration](/privacy/private-data-exploration/)

--- a/pseo/cli-duckdb-client.md
+++ b/pseo/cli-duckdb-client.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: "CLI DuckDB Client — A TUI Built Around DuckDB"
+description: "Quack is a CLI client built around DuckDB. Open .duckdb files, browse schemas, run SQL, and explore results from a keyboard-driven terminal UI."
+permalink: /tools/cli-duckdb-client/
+---
+
+
+DuckDB ships with a solid REPL, but a REPL isn't a client. Once you're running CTEs longer than your scrollback, paging through result sets, or flipping between schemas, you want a proper UI — without leaving the terminal. Quack is that UI: a CLI client built around DuckDB first.
+
+## DuckDB-Native by Design
+
+Quack is written in Rust and treats DuckDB as its primary engine. Point it at a `.duckdb` file and you get everything the DuckDB ecosystem offers — CSV, Parquet, and JSON reads, views, indexes, user-defined functions — surfaced in a TUI instead of a bare prompt.
+
+```bash
+cargo install quack-sql
+quack path/to/analytics.duckdb
+```
+
+You can also connect to SQLite, PostgreSQL, and MySQL from the same session, but the experience is tuned for DuckDB workflows.
+
+## What the REPL Doesn't Give You
+
+**A schema explorer.** Press `Ctrl+S` for a tree view of catalogs, schemas, tables, views, indexes, and functions. Expand, jump to definition, and paste identifiers into the editor without typing them.
+
+**A real editor.** Modal vim-style editing with syntax highlighting, autocompletion, and multi-line buffers. Write the kind of query you'd actually commit, not the kind you type once.
+
+**A results browser.** Paginated tables with sorting, filtering, column aggregates, and sparklines. Export to CSV, Parquet, or JSON from the result pane.
+
+**Tabs and persistence.** Multiple editor tabs per session. Close Quack, reopen it, and your tabs, buffers, and query history come back.
+
+**A command palette.** `Ctrl+P` opens 40+ actions, plus your own SQL snippets.
+
+## The DuckDB Query You Actually Wrote
+
+Because Quack delegates SQL execution to DuckDB itself, dialect behavior matches what you'd get at the `duckdb` CLI. Read a Parquet file directly:
+
+```sql
+SELECT region, SUM(amount) AS total
+FROM read_parquet('s3://bucket/orders/*.parquet')
+GROUP BY region
+ORDER BY total DESC;
+```
+
+Attach another DuckDB database, query a view, or call an extension function — whatever DuckDB supports, Quack runs.
+
+## Install
+
+Cargo, Homebrew, or prebuilt binaries from the [Quack GitHub repository](https://github.com/pondpilot/quack). No accounts, no telemetry, no browser dependency.
+
+## If You Want the Full GUI
+
+Quack is the terminal client in the PondPilot family. The [PondPilot App](https://app.pondpilot.io) is the same DuckDB engine in a browser, if you want to hand a colleague a URL instead of a binary.
+
+---
+
+## Related
+
+- [Terminal SQL Client](/tools/terminal-sql-client/)
+- [DuckDB Browser Tool](/duckdb/browser-tool/)
+- [Open Source SQL Editor](/use-cases/open-source-sql-editor/)

--- a/pseo/column-statistics-tool.md
+++ b/pseo/column-statistics-tool.md
@@ -1,0 +1,52 @@
+---
+layout: page
+title: "Column Statistics Tool — Per-Column Stats Without Pandas"
+description: "See histograms, null rates, distinct counts, and top values for every column in your dataset. No Pandas, no notebook — just drop a file."
+permalink: /tools/column-statistics-tool/
+---
+
+
+You have a file. You want to know, per column, how many nulls there are, how many distinct values, what the distribution looks like, and what the top categories are. You could spin up Jupyter, load Pandas, and write `df.describe()` plus a handful of `value_counts()` calls. Or you could drop the file into Sonar and have all of it on screen in seconds.
+
+## Stats Per Column
+
+For every column in your dataset, Sonar computes:
+
+- **Type** (integer, decimal, string, date, boolean)
+- **Null count and null rate**
+- **Distinct value count**
+- **Histogram** for numeric columns
+- **Top values with frequency bars** for categorical columns
+- **Min, max, mean** where applicable
+
+No `import pandas as pd`. No kernel to restart. No waiting on a `df = pd.read_csv(...)` call that runs out of memory on a 2 GB file.
+
+## Why Not Pandas?
+
+Pandas is great, but it's overkill for "what's in this file?" You load the whole frame into memory, you write boilerplate, and you still have to render the histograms yourself. For quick column-level inspection, a dedicated profiling UI is faster.
+
+Sonar uses DuckDB under the hood, which is column-oriented and streams aggregates efficiently. Files that make Pandas swap are comfortable for DuckDB.
+
+## Works on the Formats You Actually Have
+
+CSV, TSV, Parquet, JSON, JSONL, Excel, DuckDB databases, SAS, SPSS, Stata. Drop the file in — Sonar figures out the rest.
+
+## Findings Highlight What Matters
+
+Beyond raw stats, Sonar's findings engine ranks columns by data quality issues — high null rates, constant columns, candidate primary keys. You see which columns deserve attention without scrolling through all of them.
+
+## Everything Stays Local
+
+Sonar runs in the browser tab. Your data is not uploaded, not logged, not processed on a server. Close the tab and it's gone.
+
+## Try It
+
+[Launch Sonar](https://sonar.pondpilot.io) and see column statistics for your dataset in seconds.
+
+---
+
+## Related
+
+- [Data Quality Check Tool](/tools/data-quality-check-tool/)
+- [Analyze CSV in Browser](/use-cases/analyze-csv-in-browser/)
+- [Jupyter Notebook Alternative for SQL](/alternatives/jupyter-notebook-alternative-for-sql/)

--- a/pseo/csv-to-json-converter.md
+++ b/pseo/csv-to-json-converter.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: "Convert CSV to JSON Online — SQL-Powered, In-Browser"
+description: "Convert CSV files to JSON in your browser. Filter rows, reshape records, and build nested structures with SQL. No uploads."
+permalink: /formats/csv-to-json-converter/
+---
+
+
+Need to turn a CSV into JSON for an API, a config file, or a frontend fixture? PondPilot converts CSV to JSON directly in the browser, with SQL in between so you can filter and reshape before export.
+
+## How to Convert
+
+1. Open [app.pondpilot.io](https://app.pondpilot.io)
+2. Drop in your `.csv` file
+3. Query and reshape with SQL
+4. Export as JSON
+
+Everything runs locally via DuckDB WebAssembly. No server, no upload.
+
+## Filter Rows Before Exporting
+
+Most CSV-to-JSON tools dump every row. That's rarely what you want — JSON payloads are read by humans and machines that care about size.
+
+```sql
+SELECT id, name, email
+FROM read_csv_auto('contacts.csv')
+WHERE subscribed = true
+  AND email IS NOT NULL
+```
+
+Export only the rows and columns you actually need.
+
+## Build Nested Structures
+
+JSON isn't flat. DuckDB lets you construct nested objects and arrays on the way out:
+
+```sql
+SELECT
+  user_id,
+  {'first': first_name, 'last': last_name} AS name,
+  list(tag) AS tags
+FROM read_csv_auto('users.csv')
+GROUP BY user_id, first_name, last_name
+```
+
+Turn a flat CSV into a JSON shape that matches your API contract.
+
+## NDJSON or JSON Array
+
+Export as a standard JSON array or as newline-delimited JSON (NDJSON), whichever your downstream tool expects. NDJSON is nicer for streaming and log pipelines.
+
+## Privacy
+
+CSVs exported from CRMs, analytics tools, or internal dashboards often contain names, emails, and account data. PondPilot processes everything in-browser, so nothing is uploaded.
+
+## Get Started
+
+Visit [app.pondpilot.io](https://app.pondpilot.io) and convert your CSV to JSON.
+
+---
+
+## Related
+
+- [JSON to CSV Converter](/formats/json-to-csv-converter/)
+- [CSV to SQL Online](/use-cases/csv-to-sql-online/)
+- [Data Format Converter](/formats/data-format-converter-browser/)

--- a/pseo/csv-to-parquet-converter.md
+++ b/pseo/csv-to-parquet-converter.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: "Convert CSV to Parquet Online — In-Browser, SQL-First"
+description: "Convert CSV files to Parquet directly in your browser. Typed columns, compression, and SQL transforms before export. No uploads."
+permalink: /formats/csv-to-parquet-converter/
+---
+
+
+CSV is the lowest common denominator. Parquet is what you actually want once your files get big. PondPilot converts CSV to Parquet entirely in your browser — and lets you clean up the data with SQL on the way.
+
+## How to Convert
+
+1. Open [app.pondpilot.io](https://app.pondpilot.io)
+2. Drop in your `.csv` file
+3. Inspect the inferred schema, fix types with SQL if needed
+4. Export as Parquet
+
+The whole pipeline runs locally via DuckDB WebAssembly. Your CSV never leaves your machine.
+
+## Why Parquet?
+
+- **Compression** — Parquet files are typically 5-20x smaller than the CSV they came from
+- **Typed columns** — no more guessing whether `"007"` is a string or an integer
+- **Columnar reads** — query engines only pay for the columns they touch
+- **Portable** — Pandas, Polars, DuckDB, Spark, BigQuery, Snowflake, Athena all read it natively
+
+## Query First, Then Export
+
+Most converters do a blind one-to-one translation. PondPilot encourages you to shape the data first:
+
+```sql
+SELECT
+  user_id::BIGINT AS user_id,
+  TRY_CAST(amount AS DECIMAL(12,2)) AS amount,
+  STRPTIME(ts, '%Y-%m-%d %H:%M:%S') AS event_ts,
+  lower(trim(country)) AS country
+FROM read_csv_auto('raw.csv')
+WHERE amount IS NOT NULL
+```
+
+Export the query result as Parquet and you get a clean, well-typed file instead of a faithful copy of a messy CSV.
+
+## Handles Big CSVs
+
+DuckDB streams CSV input — it doesn't have to load the entire file into memory the way a naive script might. Multi-gigabyte CSVs convert comfortably, provided your browser has the RAM for the working set.
+
+## Privacy
+
+CSV exports from internal tools routinely contain PII, revenue numbers, and account IDs. PondPilot does everything in-browser. No server, no upload, no log file somewhere with your data in it.
+
+## Get Started
+
+Visit [app.pondpilot.io](https://app.pondpilot.io) and convert your CSV to Parquet in a few clicks.
+
+---
+
+## Related
+
+- [Excel to Parquet Converter](/formats/excel-to-parquet-converter/)
+- [Parquet Viewer Online](/formats/parquet-viewer-online/)
+- [Data Format Converter](/formats/data-format-converter-browser/)

--- a/pseo/data-analysis-for-researchers.md
+++ b/pseo/data-analysis-for-researchers.md
@@ -1,0 +1,79 @@
+---
+layout: page
+title: "Data Analysis for Researchers — Private SQL for Sensitive Datasets"
+description: "Analyze clinical, survey, SPSS, and SAS data under DUAs without uploading. PondPilot runs SQL locally in the browser, with reproducible scripts."
+permalink: /audience/data-analysis-for-researchers/
+---
+
+
+Academic research data frequently arrives with strings attached: a data-use agreement that forbids cloud storage, an IRB protocol that restricts transfer, a collaborator who shared a file on the understanding it would not leave your laptop. PondPilot is built for that reality — the analysis happens in your browser, and the data stays put.
+
+## Honors Data-Use Agreements
+
+Because PondPilot uses DuckDB-WASM, your dataset never hits a server. There is no upload step, no managed cloud, no vendor with custody of your file. That makes it straightforward to describe in an IRB application or to justify to a data steward reviewing how restricted data will be handled.
+
+## Read the Formats Researchers Actually Get
+
+CSV, TSV, Parquet, Excel, and JSON load directly. For SPSS (`.sav`), SAS (`.sas7bdat`), or Stata (`.dta`) exports, convert once with pyreadstat or R's `haven`, then work in Parquet — queries become dramatically faster and the file stays on disk.
+
+## Reproducibility Through SQL Scripts
+
+Point-and-click analyses are hard to replicate. A saved `.sql` script is a literal description of what you did: every filter, every join, every derived variable.
+
+```sql
+-- Adverse event rate by treatment arm, adults only
+SELECT
+  t.arm,
+  COUNT(DISTINCT t.subject_id) AS n_subjects,
+  SUM(CASE WHEN ae.severity IN ('moderate', 'severe') THEN 1 ELSE 0 END) AS ae_events,
+  ROUND(
+    100.0 * SUM(CASE WHEN ae.severity IN ('moderate', 'severe') THEN 1 ELSE 0 END)
+    / COUNT(DISTINCT t.subject_id),
+    2
+  ) AS ae_per_100
+FROM 'trial_subjects.parquet' t
+LEFT JOIN 'adverse_events.parquet' ae USING (subject_id)
+WHERE t.age >= 18
+GROUP BY t.arm
+ORDER BY ae_per_100 DESC;
+```
+
+Paste that into a supplementary materials file and any reviewer with the same data can reproduce the row.
+
+## Survey Data Cleaning
+
+Survey exports are messy — Likert items coded as strings, skip logic leaving nulls, free-text columns you want to exclude. SQL handles all of it without a 200-line script:
+
+```sql
+SELECT
+  respondent_id,
+  CASE q3
+    WHEN 'Strongly disagree' THEN 1
+    WHEN 'Disagree' THEN 2
+    WHEN 'Neutral' THEN 3
+    WHEN 'Agree' THEN 4
+    WHEN 'Strongly agree' THEN 5
+  END AS q3_score
+FROM 'survey_wave2.csv'
+WHERE consent_given = TRUE;
+```
+
+## Works Offline
+
+Install PondPilot as a PWA and analyze sensitive data on a laptop that is air-gapped or simply on a plane. No connectivity, no problem.
+
+## Free and Open Source
+
+No license to expense, no grant line-item, no institutional site agreement. Graduate students and PIs use the same tool.
+
+## Start Analyzing
+
+[Open PondPilot](https://app.pondpilot.io) — private SQL for research data.
+
+---
+
+## Related
+
+- [Data Tools for Journalists](/audience/data-tools-for-journalists/)
+- [Private Data Exploration](/privacy/private-data-exploration/)
+- [Data Analysis Without Uploading](/privacy/data-analysis-without-uploading/)

--- a/pseo/data-profiling-tool.md
+++ b/pseo/data-profiling-tool.md
@@ -1,0 +1,50 @@
+---
+layout: page
+title: "Data Profiling Tool — Instant Column Stats in Your Browser"
+description: "Drop a file and get column types, null rates, distinct counts, and distributions in seconds. No uploads, no setup. Powered by Sonar."
+permalink: /tools/data-profiling-tool/
+---
+
+
+Before you write a single query, you need to know what's in the file. Sonar is a data profiling tool that reads your dataset in the browser and shows column types, null rates, distinct counts, and distributions — no uploads, no account, no Python environment.
+
+## What You Get in Seconds
+
+Drop a CSV, Parquet, JSON, Excel, DuckDB, SAS, SPSS, or Stata file and Sonar profiles it:
+
+- **Inferred types** per column (INT, DEC, STR, DATE, etc.)
+- **Null counts and null rate** across the whole dataset
+- **Distinct value counts** — spot candidate primary keys and constant columns
+- **Min / max / mean** for numeric columns
+- **Top values and frequency bars** for categorical columns
+- **Row and column counts** at a glance
+
+The overview shows up in seconds. Deeper statistics stream in progressively as they compute, so you don't wait for a full pass before you start looking.
+
+## Findings, Not Just Numbers
+
+Sonar runs 12+ deterministic rules over the profile and surfaces findings ranked by severity — columns with more than 50% nulls, candidate primary keys, constant columns, suspicious outliers. You see the problems before you go looking for them.
+
+## In-Browser, No Uploads
+
+Sonar runs entirely on your machine via DuckDB WebAssembly. The file is parsed in the browser tab — it never touches a server. That matters when you're profiling production exports, PII, or anything under a data use agreement.
+
+## Compare Profiles Over Time
+
+Export a baseline profile, then re-profile the next delivery. Sonar's Profile Compare mode highlights drift — new nulls, shifted top values, type changes — so you catch regressions before they hit your pipeline.
+
+## Hand Off to SQL When You're Ready
+
+Profiling answers "what's here?" When you're ready to ask "what does it mean?", Sonar hands the dataset off to the PondPilot App with one click for deeper SQL querying.
+
+## Try Sonar
+
+[Launch Sonar](https://sonar.pondpilot.io) and profile your first file. Free, open source, runs locally.
+
+---
+
+## Related
+
+- [Data Quality Check Tool](/tools/data-quality-check-tool/)
+- [Analyze CSV in Browser](/use-cases/analyze-csv-in-browser/)
+- [Compare Datasets in Browser](/use-cases/compare-datasets-in-browser/)

--- a/pseo/data-tool-for-accountants.md
+++ b/pseo/data-tool-for-accountants.md
@@ -1,0 +1,92 @@
+---
+layout: page
+title: "Data Tool for Accountants — SQL on GL Exports, Client Data Stays Local"
+description: "Run reconciliations and trial-balance checks on journal-entry CSVs in the browser. PondPilot keeps client data on your machine — no uploads."
+permalink: /audience/data-tool-for-accountants/
+---
+
+
+Accounting work lives in exports. A general-ledger dump from NetSuite, a journal-entry CSV from QuickBooks, a trial balance from the client's bookkeeper. You need to reconcile, tie out, and test — without sending the client's books to a SaaS vendor. PondPilot is a local SQL workbench built for that.
+
+## Client Data Doesn't Leave Your Machine
+
+Engagement letters and confidentiality obligations make uploading client data a real problem. PondPilot processes everything in your browser via DuckDB-WASM. No file ever reaches a server, no account is required, no vendor can subpoena what it doesn't have.
+
+## Journal-Entry Exports, Queried Directly
+
+Drop a `gl_detail.csv` into [app.pondpilot.io](https://app.pondpilot.io) and start testing:
+
+```sql
+-- Debits must equal credits, per entry
+SELECT
+  entry_id,
+  SUM(debit) AS total_debit,
+  SUM(credit) AS total_credit,
+  SUM(debit) - SUM(credit) AS imbalance
+FROM 'gl_detail.csv'
+GROUP BY entry_id
+HAVING ROUND(SUM(debit) - SUM(credit), 2) <> 0
+ORDER BY ABS(SUM(debit) - SUM(credit)) DESC;
+```
+
+## Trial Balance from the GL
+
+Rebuild a trial balance from journal detail and compare to what the client reported:
+
+```sql
+SELECT
+  account_number,
+  account_name,
+  SUM(debit) - SUM(credit) AS net_movement
+FROM 'gl_detail.csv'
+WHERE posting_date BETWEEN DATE '2024-01-01' AND DATE '2024-12-31'
+GROUP BY account_number, account_name
+ORDER BY account_number;
+```
+
+Join that against the client's submitted TB file and flag differences in one query.
+
+## Reconciliation Queries
+
+Bank reconciliations, intercompany matches, AR aging — all SQL-shaped problems:
+
+```sql
+-- Unmatched bank transactions
+SELECT b.*
+FROM 'bank.csv' b
+LEFT JOIN 'gl_cash.csv' g
+  ON b.amount = g.amount AND b.value_date = g.posting_date
+WHERE g.entry_id IS NULL;
+```
+
+## Control Testing and Sampling
+
+Pull a JE sample for testing — weekends, round-dollar postings, entries by users who shouldn't be posting:
+
+```sql
+SELECT *
+FROM 'gl_detail.csv'
+WHERE dayofweek(posting_date) IN (0, 6)
+   OR amount % 1000 = 0
+   OR posted_by IN ('admin', 'system');
+```
+
+## Large Ledgers Without a Database
+
+Multi-year GL files with millions of lines open fine here. DuckDB is built for analytical scans and runs columnar operations that Excel can't handle at that size.
+
+## Works Offline
+
+Install as a PWA and run the full engagement on a locked-down laptop with no outbound network.
+
+## Start the Engagement
+
+[Open PondPilot](https://app.pondpilot.io) — SQL on client data, nothing uploaded.
+
+---
+
+## Related
+
+- [Data Analysis for Startups](/audience/data-analysis-for-startups/)
+- [Private Data Exploration](/privacy/private-data-exploration/)
+- [Excel Alternative for Data Analysis](/alternatives/excel-alternative-for-data-analysis/)

--- a/pseo/data-tool-for-compliance-analysts.md
+++ b/pseo/data-tool-for-compliance-analysts.md
@@ -1,0 +1,86 @@
+---
+layout: page
+title: "Data Tool for Compliance Analysts — Review Sensitive Exports Locally"
+description: "Run SQL on access logs, transaction exports, and control samples without uploading to SaaS. PondPilot processes data in the browser, not the cloud."
+permalink: /audience/data-tool-for-compliance-analysts/
+---
+
+
+Compliance and internal-audit analysts work with exports that carry real obligations: access logs, transaction monitoring pulls, HR records, privileged user lists. Sending any of it through a SaaS analytics tool creates a second custody problem. PondPilot keeps the file on your workstation and runs SQL against it in the browser.
+
+## Nothing Leaves the Endpoint
+
+DuckDB-WASM executes inside the browser. There's no upload, no server-side processing, no third-party account holding the data. For analysts working inside SOX, PCI, HIPAA, or SOC 2 control scopes, that architecture simplifies the handling story.
+
+## Control Testing with SQL
+
+A lot of control testing is SQL-shaped once the data is exported. Segregation-of-duties checks, terminated-user access reviews, privileged-action review, change-approval testing — all translate cleanly.
+
+```sql
+-- Terminated users with post-termination system access
+SELECT
+  h.user_id,
+  h.termination_date,
+  a.event_ts,
+  a.system,
+  a.action
+FROM 'hr_terminations.csv' h
+JOIN 'access_logs.csv' a USING (user_id)
+WHERE a.event_ts > h.termination_date
+ORDER BY a.event_ts;
+```
+
+Any row returned is a finding. Save the query as the workpaper evidence of the test procedure.
+
+## Segregation-of-Duties Checks
+
+```sql
+-- Users who both created and approved the same vendor
+SELECT DISTINCT c.vendor_id, c.created_by AS creator
+FROM 'vendor_creates.csv' c
+JOIN 'vendor_approvals.csv' a
+  ON c.vendor_id = a.vendor_id
+ AND c.created_by = a.approved_by;
+```
+
+## Sampling for Substantive Testing
+
+Pull a reproducible sample for manual review, with a seed you can document:
+
+```sql
+SELECT *
+FROM 'journal_entries.csv'
+WHERE posting_date BETWEEN DATE '2024-01-01' AND DATE '2024-12-31'
+ORDER BY hash(entry_id || '2024-audit-seed')
+LIMIT 60;
+```
+
+Same seed, same sample — the test is reproducible by the external auditor or by next year's you.
+
+## Large Logs, Modest Laptop
+
+Access-log exports can hit tens of millions of rows. DuckDB's columnar engine handles that on a standard work laptop without a separate database.
+
+## Audit-Friendly Evidence
+
+A saved `.sql` file plus the input export is a clean workpaper: inputs, procedure, and result are all reviewable. No screenshots of a BI tool, no "I did some filtering in Excel" narrative.
+
+## No Account, No Logs
+
+PondPilot requires no signup. There's no vendor-side record of which files you opened or what you queried. That removes a category of questions from every risk review of your tooling.
+
+## Works Offline
+
+Install as a PWA and operate on a workstation without outbound connectivity. Useful when the data classification policy says the file cannot touch the network at all.
+
+## Start a Review
+
+[Open PondPilot](https://app.pondpilot.io) — local SQL for sensitive exports.
+
+---
+
+## Related
+
+- [Data Tools for Journalists](/audience/data-tools-for-journalists/)
+- [Private Data Exploration](/privacy/private-data-exploration/)
+- [Data Analysis Without Uploading](/privacy/data-analysis-without-uploading/)

--- a/pseo/data-tool-for-data-engineers.md
+++ b/pseo/data-tool-for-data-engineers.md
@@ -1,0 +1,90 @@
+---
+layout: page
+title: "Data Tool for Data Engineers — Inspect Parquet and Iceberg in the Browser"
+description: "Sanity-check pipeline outputs, peek at Parquet and Iceberg files, and debug without spinning up infra. PondPilot runs DuckDB in your browser."
+permalink: /audience/data-tool-for-data-engineers/
+---
+
+
+You just dropped a new Parquet partition into S3 and you want to confirm the row counts and schema before the downstream DAG picks it up. Spinning up a notebook, starting a cluster, or SSHing into the jumpbox is overkill. PondPilot gives you DuckDB in a browser tab — point it at a file and interrogate it.
+
+## Quick Sanity Checks on Pipeline Outputs
+
+Drag a Parquet file from your file manager into [app.pondpilot.io](https://app.pondpilot.io) and start inspecting:
+
+```sql
+-- Row count, null rates, min/max on the partition key
+SELECT
+  COUNT(*) AS rows,
+  COUNT(*) FILTER (WHERE user_id IS NULL) AS null_user_id,
+  MIN(event_ts) AS min_ts,
+  MAX(event_ts) AS max_ts
+FROM 'events_2024-12-15.parquet';
+```
+
+```sql
+-- Schema introspection
+DESCRIBE SELECT * FROM 'events_2024-12-15.parquet';
+```
+
+## Compare Two Runs
+
+Diff yesterday's partition against today's to catch schema drift or silent volume drops:
+
+```sql
+WITH today AS (
+  SELECT source, COUNT(*) AS n FROM 'events_2024-12-15.parquet' GROUP BY source
+),
+yesterday AS (
+  SELECT source, COUNT(*) AS n FROM 'events_2024-12-14.parquet' GROUP BY source
+)
+SELECT
+  COALESCE(t.source, y.source) AS source,
+  y.n AS yesterday_rows,
+  t.n AS today_rows,
+  ROUND(100.0 * (t.n - y.n) / NULLIF(y.n, 0), 1) AS pct_change
+FROM today t
+FULL OUTER JOIN yesterday y USING (source)
+ORDER BY ABS(COALESCE(pct_change, 0)) DESC;
+```
+
+## Iceberg and Remote Files
+
+DuckDB's Iceberg and `httpfs` extensions let you read directly from object storage URLs. Query an Iceberg table snapshot or an S3-hosted Parquet without materializing locally — handy when the file is too large to download but you only need a slice.
+
+## Verify dbt and Airflow Outputs
+
+Before promoting a model, read the target file and check invariants:
+
+```sql
+-- No duplicate primary keys
+SELECT order_id, COUNT(*) AS c
+FROM 'dim_orders.parquet'
+GROUP BY order_id HAVING COUNT(*) > 1;
+```
+
+If this returns zero rows, the uniqueness contract holds. Faster than waiting for the next scheduled run of a test suite.
+
+## No Infra, No Credentials
+
+You don't need Snowflake access, a warehouse role, or a Kubernetes pod to poke at a file. Your laptop has enough horsepower for multi-million-row scans, and the browser has an engine waiting.
+
+## Scripts Live in Tabs
+
+Save useful debugging queries as `.sql` files in the repo next to the DAG they're checking. Future-you, or the on-call engineer at 2am, will thank present-you.
+
+## Works Offline
+
+PWA-installable. Useful when you're debugging a local pipeline run on a plane or behind a firewall.
+
+## Open the Tool
+
+[app.pondpilot.io](https://app.pondpilot.io) — DuckDB in a browser, zero setup.
+
+---
+
+## Related
+
+- [Browser SQL Analytics](/use-cases/browser-sql-analytics/)
+- [DuckDB Online Playground](/duckdb/online-playground/)
+- [Data Analysis for Startups](/audience/data-analysis-for-startups/)

--- a/pseo/dbt-lineage-alternative.md
+++ b/pseo/dbt-lineage-alternative.md
@@ -1,0 +1,68 @@
+---
+layout: page
+title: "dbt Lineage Alternative — SQL Lineage Without the Pipeline"
+description: "Want dbt-style lineage without adopting dbt? FlowScope parses raw SQL and produces column-level lineage diagrams in the browser. No models, no project."
+permalink: /alternatives/dbt-lineage-alternative/
+---
+
+
+One of the best things dbt gives you is a lineage graph — a picture of how models, columns, and sources depend on each other. But that graph only exists if you've already adopted dbt: project structure, `ref()` calls, a manifest, a runner. If you just want the lineage view for SQL you already have, FlowScope gets you there without the pipeline.
+
+## Complement, Not Replacement
+
+FlowScope isn't a transformation framework. It won't schedule your models, materialize tables, or manage environments — dbt does all of that, and does it well. What FlowScope does is the lineage part, directly from SQL text, for any SQL you can paste in.
+
+Think of it as "dbt's lineage without the dbt project."
+
+## What FlowScope Does
+
+Paste a SQL query — a single `SELECT`, a stack of CTEs, a whole transformation script — and FlowScope:
+
+- Parses the SQL
+- Resolves CTEs, aliases, subqueries, joins, and unions
+- Produces a column-level lineage diagram showing which source columns feed each output column
+
+No `dbt_project.yml`. No `ref()` rewrites. No compiled manifest. Just SQL in, diagram out.
+
+```sql
+WITH customer_orders AS (
+  SELECT user_id AS customer_id,
+         COUNT(*) AS num_orders,
+         SUM(amount) AS total_spent
+  FROM warehouse.core.orders
+  GROUP BY user_id
+)
+SELECT * FROM customer_orders;
+```
+
+FlowScope traces `total_spent` back to `orders.amount`, `num_orders` back to the row count, and `customer_id` back to `orders.user_id`.
+
+## When This Beats Setting Up dbt
+
+**Ad-hoc analysis.** You have one complicated query to debug, not a project to build. Spinning up dbt to visualize it is overkill.
+
+**Existing non-dbt SQL.** Legacy pipelines, stored procedures, ETL tools that emit SQL — none of which are dbt models. FlowScope reads the SQL directly.
+
+**Code review.** Reviewing a PR that changes SQL? Paste the before and after into FlowScope and see the lineage diff without compiling a project.
+
+**Documentation.** Generate a lineage diagram for a query and drop it into the doc. No manifest to keep in sync.
+
+## When dbt's Built-In Lineage Is Better
+
+If you're already running dbt, its docs site gives you lineage across your entire project — including dependencies between models, tests, and sources. FlowScope operates on one query at a time. For whole-project lineage, stay in dbt docs.
+
+## How FlowScope Runs
+
+Client-side, in your browser. Your SQL never leaves the machine — useful for queries that touch internal table names you'd rather not paste into a SaaS tool. Open source, multi-dialect, supports CTEs, subqueries, joins, and unions.
+
+## Try It
+
+Open [FlowScope](https://flowscope.pondpilot.io) and paste a query. Lineage appears instantly.
+
+---
+
+## Related
+
+- [SQL Lineage Visualization](/tools/sql-lineage-visualization/)
+- [Column-Level Lineage Tool](/tools/column-level-lineage-tool/)
+- [SQL Editor for Documentation](/use-cases/sql-editor-for-documentation/)

--- a/pseo/excel-to-csv-converter.md
+++ b/pseo/excel-to-csv-converter.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: "Convert Excel to CSV Online — Multi-Sheet, In-Browser"
+description: "Convert Excel .xlsx files to CSV in your browser. Multi-sheet support, SQL filtering, no uploads."
+permalink: /formats/excel-to-csv-converter/
+---
+
+
+Need a CSV out of an `.xlsx` file? PondPilot converts Excel to CSV entirely in the browser, with multi-sheet support and SQL filtering before export.
+
+## How to Convert
+
+1. Open [app.pondpilot.io](https://app.pondpilot.io)
+2. Drop in your `.xlsx` file
+3. Pick a sheet (or query across sheets)
+4. Export as CSV
+
+The conversion runs locally via DuckDB WebAssembly. Your Excel file never leaves your machine.
+
+## Multi-Sheet Workbooks
+
+Real Excel files have more than one sheet — a summary tab, a raw data tab, a notes tab. PondPilot exposes each sheet as a queryable table, so you can pick the one you want or combine them:
+
+```sql
+SELECT * FROM 'report.xlsx'.Sales
+UNION ALL
+SELECT * FROM 'report.xlsx'.Refunds;
+```
+
+Export the result as a single clean CSV.
+
+## Filter and Clean First
+
+Excel files are messy — merged cells, header rows, trailing totals, blank columns. Convert what you actually need:
+
+```sql
+SELECT
+  TRIM(customer) AS customer,
+  TRY_CAST(amount AS DECIMAL(12,2)) AS amount,
+  STRPTIME(date_text, '%m/%d/%Y')::DATE AS order_date
+FROM 'report.xlsx'.Sales
+WHERE customer IS NOT NULL
+  AND customer NOT ILIKE '%total%';
+```
+
+Strip out the junk, fix the types, and export a CSV that downstream tools will actually accept.
+
+## Why CSV Instead of Parquet?
+
+Sometimes the person on the other end just wants a CSV they can open in their own spreadsheet or import into a legacy tool. CSV is the universal fallback. If you have the choice, Parquet is better — see the Parquet converter.
+
+## Privacy
+
+Excel files from finance, HR, and operations almost always contain sensitive data. PondPilot processes everything locally in your browser. No server processes your spreadsheet.
+
+## Get Started
+
+Visit [app.pondpilot.io](https://app.pondpilot.io) and convert your Excel file to CSV.
+
+---
+
+## Related
+
+- [Excel to Parquet Converter](/formats/excel-to-parquet-converter/)
+- [Excel Alternative for Data Analysis](/alternatives/excel-alternative-for-data-analysis/)
+- [Data Format Converter](/formats/data-format-converter-browser/)

--- a/pseo/exploratory-data-analysis-browser.md
+++ b/pseo/exploratory-data-analysis-browser.md
@@ -1,0 +1,56 @@
+---
+layout: page
+title: "Exploratory Data Analysis in the Browser — Profile, Query, Export"
+description: "A full EDA workflow in the browser: profile the file with Sonar, query it with PondPilot, export clean results. No uploads, no setup."
+permalink: /use-cases/exploratory-data-analysis-browser/
+---
+
+
+Exploratory data analysis is a loop: open a file, figure out what's in it, ask questions, export what's useful. The PondPilot toolchain runs that whole loop in the browser — no uploads, no environment setup, no account.
+
+## The EDA Workflow
+
+**1. Open the file.** Drag a CSV, Parquet, JSON, Excel, DuckDB, SAS, SPSS, or Stata file into the browser. DuckDB WebAssembly parses it locally.
+
+**2. Profile it.** [Sonar](https://sonar.pondpilot.io) gives you column types, null rates, distinct counts, histograms, and top values in seconds. A findings panel surfaces data quality issues — high-null columns, candidate primary keys, constant columns — ranked by severity.
+
+**3. Query it.** When profiling raises a question, hand the dataset off to [PondPilot](https://app.pondpilot.io) with one click for deeper SQL querying.
+
+```sql
+-- Which customer segments have the highest refund rate?
+SELECT segment,
+       COUNT(*) as orders,
+       SUM(CASE WHEN refunded THEN 1 ELSE 0 END) as refunds,
+       ROUND(100.0 * SUM(CASE WHEN refunded THEN 1 ELSE 0 END) / COUNT(*), 2) as pct
+FROM orders.parquet
+GROUP BY segment
+ORDER BY pct DESC;
+```
+
+**4. Export.** Dump filtered results to CSV, Parquet, JSON, or Excel.
+
+## Why Do EDA in the Browser?
+
+**No setup friction.** No `pip install`, no virtualenv, no kernel dying halfway through. Open a tab and start.
+
+**Privacy by default.** EDA happens on raw, unmassaged data — often the most sensitive kind. Sonar and PondPilot both run entirely in-browser via DuckDB WebAssembly. Files never leave your machine.
+
+**Works on the formats you have.** You don't need to pre-convert a SAS file to CSV or an Excel workbook to Parquet. Drop it in.
+
+**Handles real-world sizes.** DuckDB is an analytical engine. Files that choke Pandas or Excel are fine here.
+
+## Profile First, Then Query
+
+It's tempting to skip straight to SQL, but profiling first saves time. Sonar tells you which columns are mostly null, which are constant, which are candidate keys, and which have suspicious distributions. Those answers shape better queries.
+
+## Try the Loop
+
+[Start with Sonar](https://sonar.pondpilot.io) to profile, or [open PondPilot](https://app.pondpilot.io) to jump straight to SQL. Free, open source, fully local.
+
+---
+
+## Related
+
+- [Analyze CSV in Browser](/use-cases/analyze-csv-in-browser/)
+- [Data Quality Check Tool](/tools/data-quality-check-tool/)
+- [Compare Datasets in Browser](/use-cases/compare-datasets-in-browser/)

--- a/pseo/healthcare-data-analysis-private.md
+++ b/pseo/healthcare-data-analysis-private.md
@@ -1,0 +1,62 @@
+---
+layout: page
+title: "Private Healthcare Data Analysis — Clinical and Claims Data, Locally"
+description: "Analyze clinical datasets, claims exports, and SAS/SPSS research files in your browser. PondPilot keeps PHI on your workstation."
+permalink: /use-cases/healthcare-data-analysis-private/
+---
+
+
+Clinical researchers, health economists, and claims analysts work with some of the most sensitive data around. PondPilot gives you SQL over that data without sending a single row to a vendor — your files stay on your workstation.
+
+## Claims and EHR Exports
+
+Most health data arrives as CSV, Parquet, or fixed-width text. Drop it into [PondPilot](https://app.pondpilot.io) and query it with full DuckDB SQL:
+
+```sql
+SELECT
+  diagnosis_code,
+  COUNT(DISTINCT patient_id) as patients,
+  AVG(total_paid) as avg_paid,
+  SUM(total_paid) as total_spend
+FROM claims_2025.parquet
+WHERE service_date BETWEEN '2025-01-01' AND '2025-06-30'
+GROUP BY diagnosis_code
+ORDER BY total_spend DESC
+LIMIT 25;
+```
+
+No upload. No cloud warehouse bill. No vendor sitting between you and PHI.
+
+## SAS and SPSS Files for Research Cohorts
+
+A lot of health research data still lives in SAS (`.sas7bdat`) and SPSS (`.sav`) files. DuckDB's [read_stat](https://github.com/mettekou/duckdb-read-stat) community extension loads both directly. Point PondPilot at the file and query it without round-tripping through a proprietary statistics package just to see the columns.
+
+This is particularly useful for secondary analysis of public-use files (MEPS, NHANES, HCUP) and for inspecting collaborator-supplied research extracts before pulling them into a full analysis environment.
+
+## Cohort Building, Locally
+
+Window functions and CTEs cover most cohort logic — index events, washout periods, continuous enrollment, first-observed diagnoses. DuckDB gives you all of that. Your cohort definition stays on your machine, which matters when the cohort criteria themselves are sensitive.
+
+## Join Across Sources
+
+Open a claims CSV next to a member eligibility file and a provider roster. JOIN across all three in a single session. No ETL pipeline, no staging schema, no IT ticket.
+
+## Why This Matters
+
+Uploading PHI to a third-party SaaS tool — even "just for a quick look" — is the kind of thing that derails an IRB review, a DUA, or a compliance audit. PondPilot avoids the problem by design: there is no upload endpoint.
+
+## Honest Caveats
+
+This is a SQL exploration tool. It's not a statistical package, not a validated clinical platform, not a substitute for your analysis-of-record environment. Use it for exploration, cohort sizing, data QA, and ad-hoc questions.
+
+## Start Querying
+
+[Open PondPilot](https://app.pondpilot.io) and drop in your first file. Works offline once loaded.
+
+---
+
+## Related
+
+- [HIPAA-Friendly Data Tool](/privacy/hipaa-compliant-data-tool/)
+- [Private Data Exploration](/privacy/private-data-exploration/)
+- [Air-Gapped Data Analysis](/privacy/air-gapped-data-analysis/)

--- a/pseo/hex-alternative.md
+++ b/pseo/hex-alternative.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: "Hex Alternative — Private, Local SQL in Your Browser"
+description: "A private Hex alternative for solo analysts. PondPilot runs SQL locally in your browser — no cloud upload, no account, no seat license."
+permalink: /alternatives/hex-alternative/
+---
+
+
+[Hex](https://hex.tech/) is a polished collaborative notebook for data teams — SQL, Python, charts, apps, shared workspaces. It's a cloud SaaS, which means your data lives on their infrastructure. PondPilot is for the opposite situation: you're working alone, you can't or don't want to upload, and you just need SQL on your files.
+
+## PondPilot vs Hex
+
+| | Hex | PondPilot |
+|---|---|---|
+| **Where it runs** | Hex cloud | Your browser (WASM) |
+| **Account** | Required | None |
+| **Collaboration** | Real-time multiplayer, comments, apps | Single-user |
+| **Languages** | SQL + Python + charts + apps | SQL |
+| **Data source** | Warehouse connections, uploads | Local files (CSV, Parquet, JSON, DuckDB) |
+| **Privacy** | Data uploaded to Hex | Data stays in the browser tab |
+| **Cost** | Free tier + paid seats | Free |
+
+## When PondPilot Fits
+
+**Privacy-sensitive data:** Medical, financial, HR, customer PII — things you shouldn't upload to a third-party SaaS. PondPilot processes everything locally.
+
+**You're solo:** It's just you and a file. You don't need real-time collaboration or a team workspace.
+
+**No procurement overhead:** You don't want to get a new vendor approved, sign a DPA, or justify another seat license to ask one question.
+
+**Quick and throwaway:** A five-minute analysis that shouldn't require a project, a workspace, and an account.
+
+## When Hex Fits
+
+**Team collaboration:** Hex is genuinely good at shared editing, comments, and publishing analyses as apps. PondPilot has none of that.
+
+**Python + SQL + charts in one doc:** Hex's notebook is polyglot and visual. PondPilot is SQL-only with a results grid.
+
+**Data apps for stakeholders:** Hex lets you ship parameterized apps to non-technical users. PondPilot is a tool you use, not one you publish.
+
+**Live warehouse queries:** Hex connects to Snowflake, BigQuery, Databricks, and so on. PondPilot works with files you load.
+
+## What PondPilot Isn't
+
+PondPilot isn't a notebook, isn't collaborative, and doesn't run Python. It's a SQL editor backed by DuckDB-WASM. If your workflow depends on mixing languages or shipping apps, Hex is the right tool; PondPilot won't match it.
+
+## The Honest Positioning
+
+Hex is a product for data teams. PondPilot is a utility for a single analyst with a file. They solve related problems from opposite ends — team-first cloud vs. solo-first local.
+
+## Try PondPilot
+
+[Open PondPilot](https://app.pondpilot.io) — no upload, no account, no waiting on procurement.
+
+---
+
+## Related
+
+- [Mode Analytics Alternative](/alternatives/mode-analytics-alternative/)
+- [Jupyter Notebook Alternative for SQL](/alternatives/jupyter-notebook-alternative-for-sql/)
+- [Google Sheets Alternative (Private)](/alternatives/google-sheets-alternative-private/)

--- a/pseo/hipaa-compliant-data-tool.md
+++ b/pseo/hipaa-compliant-data-tool.md
@@ -1,0 +1,58 @@
+---
+layout: page
+title: "HIPAA-Friendly Data Tool — No PHI Leaves Your Browser"
+description: "Analyze PHI without sending it to a vendor. PondPilot runs SQL on your machine — no BAA required because we never receive your data."
+permalink: /privacy/hipaa-compliant-data-tool/
+---
+
+
+HIPAA compliance is a property of workflows, not software labels. PondPilot is not "HIPAA certified" — there is no such certification. What PondPilot is: a SQL tool that never receives your data, which makes it easier to fit into HIPAA-compliant workflows.
+
+## Why No BAA Is Needed
+
+A Business Associate Agreement is required when a vendor handles Protected Health Information on your behalf. PondPilot doesn't handle your data. DuckDB runs as WebAssembly inside your browser tab. Your CSVs, Parquet files, and query results stay on your workstation.
+
+No server processes PHI. No logs capture queries. No telemetry reports usage. There's nothing for a BAA to cover because we're not a business associate — we're a static web app your browser downloads and runs locally.
+
+## What You Still Need to Do
+
+We're honest about scope. Using PondPilot doesn't make your overall workflow HIPAA-compliant. You still need:
+
+- Encrypted disks on the workstations running the browser
+- Access controls on the machine itself
+- Policies for how PHI files are obtained, stored, and deleted
+- Your own risk analysis covering browser cache, downloads folder, and session state
+
+PondPilot removes the "third-party vendor with access to PHI" line item from your risk register. The rest is still on you.
+
+## Query PHI Without Uploading
+
+```sql
+SELECT patient_id, encounter_date, diagnosis_code, COUNT(*) as visit_count
+FROM encounters.csv
+WHERE encounter_date >= '2025-01-01'
+GROUP BY patient_id, encounter_date, diagnosis_code
+HAVING visit_count > 3;
+```
+
+Run the query, review the cohort, close the tab. No trace on anyone else's server.
+
+## Auditable by Design
+
+PondPilot is [open source](https://github.com/pondpilot). Your security officer can review the code, watch browser network traffic during use, and confirm that no data leaves the workstation. That's a much shorter audit than evaluating a cloud analytics vendor's SOC 2 report.
+
+## Works on Locked-Down Networks
+
+Install PondPilot as a PWA on a connected machine, then use it offline — on a segmented clinical network, inside a secure research enclave, or on a workstation with outbound traffic blocked. No "call home", no update pings.
+
+## Get Started
+
+[Open PondPilot](https://app.pondpilot.io). No account, no signup, no data collection. If your compliance team has questions, the code is on GitHub.
+
+---
+
+## Related
+
+- [GDPR Compliant Data Tool](/privacy/gdpr-compliant-data-tool/)
+- [Private Data Exploration](/privacy/private-data-exploration/)
+- [Air-Gapped Data Analysis](/privacy/air-gapped-data-analysis/)

--- a/pseo/json-to-parquet-converter.md
+++ b/pseo/json-to-parquet-converter.md
@@ -1,0 +1,70 @@
+---
+layout: page
+title: "Convert JSON to Parquet Online — Flatten and Type in the Browser"
+description: "Convert JSON or NDJSON files to Parquet in your browser. Flatten nested structures and fix types with SQL. No uploads."
+permalink: /formats/json-to-parquet-converter/
+---
+
+
+JSON is easy to produce and painful to analyze. Parquet is the opposite. PondPilot converts JSON to Parquet in the browser — flattening nested structures and locking in types along the way.
+
+## How to Convert
+
+1. Open [app.pondpilot.io](https://app.pondpilot.io)
+2. Drop in your `.json` or `.ndjson` file
+3. Flatten and type-check with SQL
+4. Export as Parquet
+
+The conversion runs entirely in your browser via DuckDB WebAssembly. Your JSON file stays local.
+
+## Schema Inference
+
+DuckDB scans your JSON and infers a schema — column names, types, and nested structure. For large files it samples; for small ones it reads everything. You can inspect the inferred schema before exporting:
+
+```sql
+DESCRIBE SELECT * FROM read_json_auto('events.json');
+```
+
+If the inference got something wrong (numbers parsed as strings, dates as text), you can fix it before export.
+
+## Flatten Nested JSON
+
+API responses and log exports are usually deeply nested. Parquet prefers flat, typed columns. SQL bridges the gap:
+
+```sql
+SELECT
+  id,
+  created_at::TIMESTAMP AS created_at,
+  user->>'id' AS user_id,
+  user->>'country' AS country,
+  UNNEST(events) AS event
+FROM read_json_auto('payload.ndjson')
+```
+
+Extract the fields you care about, unnest arrays, and write out a flat Parquet file ready for analytics.
+
+## Why Parquet?
+
+- **Typed** — integers stay integers, timestamps stay timestamps
+- **Small** — columnar compression typically beats gzipped JSON by a wide margin
+- **Fast** — analytical engines read columns, not rows
+
+## NDJSON Works Too
+
+Newline-delimited JSON is common in logs and streaming exports. PondPilot handles both regular JSON arrays and NDJSON transparently.
+
+## Privacy
+
+Log exports and API dumps are often sensitive. PondPilot runs in your browser — the file never leaves your machine.
+
+## Get Started
+
+Visit [app.pondpilot.io](https://app.pondpilot.io) and convert your JSON to Parquet.
+
+---
+
+## Related
+
+- [JSON to CSV Converter](/formats/json-to-csv-converter/)
+- [DuckDB JSON Query](/duckdb/json-query/)
+- [Parquet Viewer Online](/formats/parquet-viewer-online/)

--- a/pseo/log-analysis-with-sql.md
+++ b/pseo/log-analysis-with-sql.md
@@ -1,0 +1,72 @@
+---
+layout: page
+title: "Log Analysis with SQL — Query JSON and CSV Logs in Your Browser"
+description: "Aggregate, filter, and pivot log exports with SQL using PondPilot. Great for JSON and NDJSON log files. Runs locally in your browser."
+permalink: /use-cases/log-analysis-with-sql/
+---
+
+
+`grep` is fine when you know what you're looking for. SQL is better when you want counts, groupings, percentiles, or trends across a log file. PondPilot runs DuckDB in your browser so you can query log exports without spinning up a log platform or uploading anything.
+
+## When SQL Beats grep
+
+- "How many 5xx responses per endpoint, per hour?"
+- "What's the p95 latency for this service today vs last week?"
+- "Which user IDs show up in auth failures across more than three IPs?"
+- "Top 20 error messages by frequency in this 2 GB NDJSON dump?"
+
+You can pipe `grep | awk | sort | uniq -c` for those, or you can write SQL once and iterate.
+
+## NDJSON and JSON Logs
+
+Most modern logging stacks export newline-delimited JSON. DuckDB reads it directly:
+
+```sql
+SELECT
+  strftime(CAST(timestamp AS TIMESTAMP), '%Y-%m-%d %H:00') as hour,
+  service,
+  status_code,
+  COUNT(*) as requests,
+  quantile_cont(duration_ms, 0.95) as p95_ms
+FROM 'app-logs.ndjson'
+WHERE status_code >= 500
+GROUP BY hour, service, status_code
+ORDER BY hour DESC, requests DESC;
+```
+
+Drop the file into [PondPilot](https://app.pondpilot.io) and run. Your log data doesn't leave your machine — which matters when it contains user IDs, IP addresses, query strings, or internal hostnames.
+
+## CSV Access Logs Too
+
+Apache/Nginx combined logs, Cloudflare exports, CDN billing dumps — anything that exports as CSV is queryable the same way. Use regex functions to pull user-agents apart, `strptime` to parse odd date formats.
+
+## Join Logs with Reference Data
+
+Have a CSV of known bad IPs? JOIN it against your access log to flag matches. Have a service catalog? JOIN it in to attribute traffic to teams.
+
+```sql
+SELECT l.*, s.owning_team
+FROM 'nginx-access.csv' l
+JOIN 'service-catalog.csv' s ON l.host = s.hostname
+WHERE l.status = 500;
+```
+
+## Big Files, Local Machine
+
+DuckDB WASM handles multi-hundred-megabyte log exports on modern hardware. For the occasional "one-off incident triage" question, that's usually enough — no need to ingest into Loki, Elastic, or BigQuery for an answer you'll look at once.
+
+## Privacy Bonus
+
+Production logs often contain PII even when they're not "supposed to". Querying them on your laptop instead of uploading to a third-party analytics tool keeps the blast radius small.
+
+## Try It
+
+[Open PondPilot](https://app.pondpilot.io), drop in your log export, and start asking real questions.
+
+---
+
+## Related
+
+- [Explore JSON Data Locally](/use-cases/explore-json-data-locally/)
+- [Analyze CSV in Browser](/use-cases/analyze-csv-in-browser/)
+- [Private Data Exploration](/privacy/private-data-exploration/)

--- a/pseo/looker-studio-alternative.md
+++ b/pseo/looker-studio-alternative.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: "Looker Studio Alternative — SQL on Your Data, Not Google's"
+description: "A Looker Studio alternative that keeps data local. PondPilot queries CSV and Parquet files in your browser — no Google account, no cloud."
+permalink: /alternatives/looker-studio-alternative/
+---
+
+
+[Looker Studio](https://lookerstudio.google.com/) (formerly Google Data Studio) is free, which is nice. It also requires a Google account, tends to pull data through Google-connected sources, and is fundamentally a cloud product. If you'd rather keep your data on your machine and write SQL against it, PondPilot is a different trade-off.
+
+## PondPilot vs Looker Studio
+
+| | Looker Studio | PondPilot |
+|---|---|---|
+| **Where it runs** | Google cloud | Your browser (WASM) |
+| **Account** | Google account required | None |
+| **Primary use** | Dashboards and reports | Ad-hoc SQL on files |
+| **Data source** | Google connectors, uploaded/linked sources | Local CSV, Parquet, JSON, DuckDB |
+| **Interface** | Drag-and-drop chart builder | SQL editor + results grid |
+| **Privacy** | Data touches Google infrastructure | Data stays in the tab |
+| **Cost** | Free (with a Google account) | Free |
+
+## When PondPilot Fits
+
+**You don't want a Google account involved:** Either you don't have one for this work, or the data can't go anywhere near Google's infrastructure.
+
+**Local, sensitive files:** Financials, HR exports, health data, private customer lists — anything you wouldn't upload to a cloud BI tool.
+
+**SQL-first workflow:** You'd rather write `GROUP BY` than drag fields onto a canvas.
+
+**Offline:** PondPilot is a PWA and runs without a network.
+
+## When Looker Studio Fits
+
+**You actually want dashboards:** Looker Studio is a dashboarding product. PondPilot is not. If your output is a shared visual report, Looker Studio is the right tool.
+
+**Google-stack data:** BigQuery, Google Analytics, Google Ads, Sheets — the connectors are built in and the integration is smooth.
+
+**Non-technical consumers:** Stakeholders can view and filter reports without knowing SQL. PondPilot expects you to write queries.
+
+**Shareable links:** Looker Studio reports have a URL you can send around. PondPilot has no sharing layer.
+
+## What PondPilot Isn't
+
+PondPilot isn't a dashboarding or reporting tool. There are no charts, no report pages, no scheduled PDF emails, no public links. It's a SQL editor that runs DuckDB in your browser against files you load. If the deliverable is a chart your boss opens tomorrow, you want Looker Studio; if the deliverable is an answer you need in the next ten minutes, PondPilot is faster.
+
+## The Privacy Trade-off
+
+Looker Studio gives you polished reporting in exchange for a Google account and Google-hosted data. PondPilot gives you SQL and privacy in exchange for dashboards and sharing. Pick the one whose trade-off matches the job.
+
+## Try PondPilot
+
+[Open PondPilot](https://app.pondpilot.io) — no Google account, no cloud.
+
+---
+
+## Related
+
+- [Mode Analytics Alternative](/alternatives/mode-analytics-alternative/)
+- [Google Sheets Alternative (Private)](/alternatives/google-sheets-alternative-private/)
+- [Excel Alternative for Data Analysis](/alternatives/excel-alternative-for-data-analysis/)

--- a/pseo/metabase-alternative.md
+++ b/pseo/metabase-alternative.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: "Metabase Alternative — Local SQL Without a BI Server"
+description: "Looking for a Metabase alternative for quick, private SQL work? PondPilot runs in your browser — no server, no account, no deploy."
+permalink: /alternatives/metabase-alternative/
+---
+
+
+[Metabase](https://www.metabase.com/) is a BI server for teams — dashboards, scheduled reports, shared questions, user permissions. It's a lot of machinery if all you want is to run a few SQL queries against a CSV on your laptop. PondPilot covers that lighter use case without the server.
+
+## PondPilot vs Metabase
+
+| | Metabase | PondPilot |
+|---|---|---|
+| **Deployment** | Self-hosted server or Metabase Cloud | Open a URL |
+| **Primary use** | Team dashboards, scheduled reports | Personal, ad-hoc SQL |
+| **Data source** | Live DB connections | Local files (CSV, Parquet, JSON, DuckDB) |
+| **Engine** | Pushes SQL to your warehouse | DuckDB-WASM in the browser |
+| **Account** | Required | None |
+| **Cost** | Free OSS (self-host) or paid cloud | Free |
+| **Privacy** | Data sits in your warehouse; server sees queries | Data never leaves the tab |
+
+## When PondPilot Fits
+
+**Ad-hoc file analysis:** You have a Parquet export or a CSV from a vendor and want to poke at it with SQL. Spinning up Metabase is overkill.
+
+**Privacy-sensitive work:** Nothing leaves your browser. No server, no cloud, no audit trail on someone else's infrastructure.
+
+**Zero setup:** No Docker, no Postgres for app state, no reverse proxy, no TLS certs. Open `app.pondpilot.io` and go.
+
+**Offline or air-gapped machines:** PondPilot is a PWA. Once loaded, it runs without a network.
+
+## When Metabase Fits
+
+**Team dashboards:** Metabase is built for shared, always-on dashboards your whole company can view. PondPilot has no server, no sharing, no scheduled refresh.
+
+**Live warehouse queries:** Metabase connects directly to Postgres, Snowflake, BigQuery, etc. PondPilot works with files you load locally.
+
+**Permissions and governance:** Row-level permissions, collections, audit logs — Metabase has all of it. PondPilot has none of it by design.
+
+**Self-service BI for non-SQL users:** Metabase's query builder lets non-technical users click their way to a chart. PondPilot assumes you write SQL.
+
+## What PondPilot Isn't
+
+PondPilot isn't a BI platform. There are no dashboards, no scheduled emails, no "pulses," no team accounts. It's a SQL editor plus DuckDB in a browser tab. If your team needs a shared reporting layer, keep Metabase. If you personally need to answer a question from a CSV right now, PondPilot is faster.
+
+## A Reasonable Split
+
+Many teams run Metabase for production dashboards and reach for something lighter for exploratory work on raw files. PondPilot fits that second slot without asking IT to provision anything.
+
+## Try PondPilot
+
+[Open PondPilot](https://app.pondpilot.io) — no server, no account, no upload.
+
+---
+
+## Related
+
+- [Mode Analytics Alternative](/alternatives/mode-analytics-alternative/)
+- [Datasette Alternative](/alternatives/datasette-alternative/)
+- [Jupyter Notebook Alternative for SQL](/alternatives/jupyter-notebook-alternative-for-sql/)

--- a/pseo/observable-alternative.md
+++ b/pseo/observable-alternative.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: "Observable Alternative — SQL-First, Local, In-Browser"
+description: "An Observable alternative for people who'd rather write SQL than JavaScript. PondPilot runs DuckDB in your browser — no account, no cloud."
+permalink: /alternatives/observable-alternative/
+---
+
+
+[Observable](https://observablehq.com/) is a reactive JavaScript notebook environment — great for interactive visualizations, D3, and bespoke data apps. It's also a SaaS with accounts, published notebooks, and a JS-first mental model. PondPilot is the opposite shape: SQL-first, local, single-user, no account.
+
+## PondPilot vs Observable
+
+| | Observable | PondPilot |
+|---|---|---|
+| **Primary language** | JavaScript (reactive cells) | SQL |
+| **Where it runs** | Observable cloud (notebooks + some local via Framework) | Your browser (WASM) |
+| **Account** | Required for the hosted product | None |
+| **Strength** | Interactive visualization, reactivity | Ad-hoc SQL on files |
+| **Data source** | Fetch anywhere in JS; DuckDB-WASM available | Local CSV, Parquet, JSON, DuckDB |
+| **Collaboration** | Share and fork notebooks | Single-user, ephemeral |
+| **Cost** | Free + paid tiers | Free |
+
+## When PondPilot Fits
+
+**You want SQL, not JavaScript:** Observable rewards people who think in reactive JS cells. If that's not you, writing a one-off `GROUP BY` shouldn't require learning a reactive runtime.
+
+**Private, local files:** PondPilot never leaves your browser. No published notebook, no cloud fetch.
+
+**Zero setup:** No account, no workspace, no fork. Open a URL, drop a file, write SQL.
+
+**Throwaway analysis:** The tab is the whole state. Close it when you're done.
+
+## When Observable Fits
+
+**Custom interactive visualizations:** If you want a D3 chart with sliders, Observable is purpose-built for that. PondPilot has no charting layer.
+
+**Publishing data stories:** Observable notebooks are meant to be shared, forked, and embedded. PondPilot is a tool, not a publishing platform.
+
+**JavaScript-native workflows:** If you already live in JS and npm, Observable's reactivity is genuinely powerful.
+
+**Teaching and exploration:** The notebook format and community examples are hard to beat for learning.
+
+## What PondPilot Isn't
+
+PondPilot isn't a notebook, isn't reactive, and doesn't run JavaScript user code. It's a SQL editor with DuckDB-WASM underneath and a results grid on top. If your end product is an interactive visualization, Observable (or Observable Framework) is the right tool; PondPilot will leave you wanting charts.
+
+## The Honest Split
+
+Observable optimizes for expressive, shareable, interactive documents. PondPilot optimizes for answering a SQL question against a local file with as little ceremony as possible. Different shapes, different jobs.
+
+## Try PondPilot
+
+[Open PondPilot](https://app.pondpilot.io) — SQL-first, local, no account.
+
+---
+
+## Related
+
+- [Jupyter Notebook Alternative for SQL](/alternatives/jupyter-notebook-alternative-for-sql/)
+- [Datasette Alternative](/alternatives/datasette-alternative/)
+- [DB Fiddle Alternative](/alternatives/db-fiddle-alternative/)

--- a/pseo/orc-viewer-online.md
+++ b/pseo/orc-viewer-online.md
@@ -1,0 +1,69 @@
+---
+layout: page
+title: "ORC Viewer Online — Open .orc Files in Your Browser"
+description: "View ORC files online via DuckDB WebAssembly. Browse schemas, run SQL, export to other formats. No uploads."
+permalink: /formats/orc-viewer-online/
+---
+
+
+ORC files live deep in the Hadoop and Hive ecosystems. They're compact and columnar, but inspecting one usually means spinning up a JVM or pulling in PyArrow. PondPilot opens `.orc` files directly in the browser.
+
+## How to View
+
+1. Open [app.pondpilot.io](https://app.pondpilot.io)
+2. Drop in your `.orc` file
+3. Instantly see the schema and a data preview
+4. Query with SQL
+
+The file is read in place via DuckDB WebAssembly. Nothing is uploaded.
+
+## Full SQL on ORC
+
+Most ORC viewers just show rows. PondPilot gives you DuckDB's full analytical SQL dialect on top of your ORC data:
+
+```sql
+SELECT
+  region,
+  COUNT(*) AS rows,
+  SUM(amount) AS total
+FROM 'warehouse.orc'
+WHERE event_date >= DATE '2024-01-01'
+GROUP BY region
+ORDER BY total DESC;
+```
+
+Aggregations, window functions, joins between ORC and other files — all available.
+
+## Schema Inspection
+
+ORC files carry detailed type and statistics metadata. The schema panel surfaces:
+
+- Column names and types
+- Nested struct, list, and map types
+- Nullability
+
+Useful when you receive an ORC file from a Hive/Spark pipeline and need to understand what's inside before writing queries.
+
+## Export to Something More Portable
+
+ORC is a fine storage format, but not everyone can read it. PondPilot lets you pull data out and export it as Parquet, CSV, JSON, or Excel — whatever your downstream tool accepts.
+
+## Handles Compressed ORC
+
+ORC files are typically ZLIB or ZSTD compressed. DuckDB's ORC reader handles compression transparently.
+
+## Privacy
+
+ORC files from a data warehouse can contain anything — customer data, transactional records, internal metrics. PondPilot processes everything in-browser. No server sees your file.
+
+## Get Started
+
+Visit [app.pondpilot.io](https://app.pondpilot.io) and open your ORC file.
+
+---
+
+## Related
+
+- [Parquet Viewer Online](/formats/parquet-viewer-online/)
+- [Arrow / Feather Viewer](/formats/arrow-feather-viewer/)
+- [Data Format Converter](/formats/data-format-converter-browser/)

--- a/pseo/parquet-to-json-converter.md
+++ b/pseo/parquet-to-json-converter.md
@@ -1,0 +1,65 @@
+---
+layout: page
+title: "Convert Parquet to JSON Online — In-Browser, SQL-First"
+description: "Convert Parquet files to JSON in the browser. Build API-shaped payloads with SQL. No uploads, no command line."
+permalink: /formats/parquet-to-json-converter/
+---
+
+
+Parquet is excellent for storage and analytics. JSON is what everything else speaks. PondPilot converts Parquet to JSON in the browser — and lets you shape the output with SQL so you can produce something a human or an API will actually accept.
+
+## How to Convert
+
+1. Open [app.pondpilot.io](https://app.pondpilot.io)
+2. Drop your `.parquet` file
+3. Write a query (or `SELECT * FROM file.parquet`)
+4. Export as JSON
+
+The whole pipeline runs locally via DuckDB WebAssembly. No server, no upload.
+
+## Shape for APIs or Readability
+
+A blind Parquet-to-JSON dump is rarely what you need. SQL lets you pick columns, rename fields, and build nested objects:
+
+```sql
+SELECT
+  order_id AS id,
+  {'name': customer_name, 'email': customer_email} AS customer,
+  total::DECIMAL(12,2) AS total,
+  order_date::DATE AS date
+FROM 'orders.parquet'
+WHERE order_date >= '2024-01-01'
+```
+
+Export the result as a JSON array or NDJSON. Good for API fixtures, debugging payloads, or sharing a readable slice of a larger dataset.
+
+## Big Parquet, Small JSON
+
+Parquet files can be huge. JSON of the whole file would be enormous and unreadable. The point of converting to JSON is usually a subset — a sample, a filter, a specific account. DuckDB's columnar reader only pulls the data your query touches, so extracting a slice from a big Parquet is fast.
+
+## Inspect First
+
+Not sure what's in the file?
+
+```sql
+DESCRIBE SELECT * FROM 'unknown.parquet';
+SELECT * FROM 'unknown.parquet' LIMIT 5;
+```
+
+See the schema, preview some rows, then write the query that produces the JSON you want.
+
+## Privacy
+
+Parquet files often hold production data, customer records, or analytics events. PondPilot processes everything in-browser. The file stays on your machine.
+
+## Get Started
+
+Visit [app.pondpilot.io](https://app.pondpilot.io) and convert your Parquet to JSON.
+
+---
+
+## Related
+
+- [Parquet Viewer Online](/formats/parquet-viewer-online/)
+- [Parquet to CSV Converter](/use-cases/parquet-to-csv-converter/)
+- [Query Parquet Files Online](/use-cases/query-parquet-files-online/)

--- a/pseo/redash-alternative.md
+++ b/pseo/redash-alternative.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: "Redash Alternative — Browser SQL Without the Self-Hosting"
+description: "A lightweight Redash alternative for ad-hoc SQL. PondPilot runs in your browser with no hosting, no accounts, and no dashboard overhead."
+permalink: /alternatives/redash-alternative/
+---
+
+
+[Redash](https://redash.io/) is a self-hosted SQL + dashboarding tool — connect a database, save queries, build dashboards, share with your team. It's a server you run, with a Postgres metadata DB, a worker queue, and users. PondPilot solves a smaller, different problem: one person, one file, quick SQL, no hosting.
+
+## PondPilot vs Redash
+
+| | Redash | PondPilot |
+|---|---|---|
+| **Deployment** | Self-hosted (or managed) server | None — open a URL |
+| **Data source** | Live DB connections | Local files (CSV, Parquet, JSON, DuckDB) |
+| **Engine** | Pushes SQL to connected DBs | DuckDB-WASM in the browser |
+| **Saved queries & dashboards** | Core feature | Not a thing |
+| **Accounts & sharing** | User accounts, groups, shared links | None |
+| **Persistence** | Metadata DB stores history | Ephemeral — lives in your tab |
+| **Cost** | Free OSS + hosting costs | Free |
+
+## When PondPilot Fits
+
+**One-shot questions:** You don't need this query tomorrow. You need an answer now, from a file you already have.
+
+**No infrastructure:** You don't want to run a Postgres-backed app to ask a question about a CSV.
+
+**Privacy:** Data stays in your browser. No server logs, no saved query history on shared infrastructure.
+
+**Disposable analysis:** Ephemeral is a feature. When you close the tab, nothing persists.
+
+## When Redash Fits
+
+**Team dashboards:** Redash is built for saved queries and shared dashboards. PondPilot doesn't save anything between sessions.
+
+**Live database queries:** Redash plugs into Postgres, MySQL, BigQuery, Snowflake, and many more. PondPilot queries local files, not live databases.
+
+**Query scheduling and alerts:** Redash can run queries on a schedule and alert on thresholds. PondPilot has no scheduler — you're the scheduler.
+
+**Shared knowledge base:** Redash accumulates institutional query history for a team. PondPilot has no memory.
+
+## What PondPilot Isn't
+
+PondPilot isn't a dashboarding tool and it isn't a shared BI layer. There's no login, no saved query library, no dashboard canvas. It's a browser tab with a SQL editor, a file loader, and DuckDB. If what you actually need is "my team's shared SQL + charts app," Redash (or its successors) is the right category; PondPilot isn't.
+
+## A Sensible Split
+
+A common pattern: Redash (or similar) for recurring team reporting, PondPilot for upstream ad-hoc exploration on raw files before anything gets productionized.
+
+## Try PondPilot
+
+[Open PondPilot](https://app.pondpilot.io) — no server to run, no account to create.
+
+---
+
+## Related
+
+- [Mode Analytics Alternative](/alternatives/mode-analytics-alternative/)
+- [Datasette Alternative](/alternatives/datasette-alternative/)
+- [DB Fiddle Alternative](/alternatives/db-fiddle-alternative/)

--- a/pseo/sql-tool-for-data-analysts.md
+++ b/pseo/sql-tool-for-data-analysts.md
@@ -1,0 +1,71 @@
+---
+layout: page
+title: "SQL Tool for Data Analysts — Ad-Hoc Queries Without the Warehouse"
+description: "Run SQL on CSV and Parquet exports in your browser. PondPilot is a fast, local analyst workbench for when the warehouse is slow, locked, or overkill."
+permalink: /audience/sql-tool-for-data-analysts/
+---
+
+
+You already know SQL. What you don't always have is a responsive environment to use it in. Warehouse queues are long, VPN is flaky, access tickets take a week, and sometimes the data you need is just a CSV someone emailed you. PondPilot is the analyst's side-scratch pad — SQL on local files, in a browser tab.
+
+## When the Warehouse Isn't the Right Tool
+
+Not every question deserves a Snowflake credit. Ad-hoc analysis on an export, a prototype join across two files, a quick sanity check before you write the real model — these jobs are friction-heavy in a warehouse and trivial in PondPilot.
+
+Drop a CSV or Parquet file into [app.pondpilot.io](https://app.pondpilot.io) and start querying. DuckDB-WASM runs the engine inside your browser, so there's no upload, no cluster, no wait.
+
+## Realistic Analyst Workflows
+
+```sql
+-- Cohort retention from an events export
+WITH first_seen AS (
+  SELECT user_id, MIN(date_trunc('month', event_ts)) AS cohort
+  FROM 'events.parquet'
+  GROUP BY user_id
+)
+SELECT
+  f.cohort,
+  date_diff('month', f.cohort, date_trunc('month', e.event_ts)) AS month_offset,
+  COUNT(DISTINCT e.user_id) AS active_users
+FROM first_seen f
+JOIN 'events.parquet' e USING (user_id)
+GROUP BY 1, 2
+ORDER BY 1, 2;
+```
+
+Cross-file joins work the same way Excel VLOOKUPs wish they did:
+
+```sql
+SELECT o.order_id, o.total, c.segment
+FROM 'orders.csv' o
+LEFT JOIN 'customers.csv' c USING (customer_id)
+WHERE o.total > 500;
+```
+
+## Handles Real Data Volumes
+
+DuckDB is columnar and vectorized. A 5M-row CSV that would hang Excel or choke pandas on a laptop runs interactively here. Parquet is even faster — PondPilot reads only the columns your query touches.
+
+## Scripts You Can Save and Share
+
+Queries live in tabs, and you can save a script as a file. Hand your reproduction steps to a teammate as a `.sql` file instead of a screenshot and a verbal explanation.
+
+## Private by Default
+
+That export with PII columns stays on your machine. Nothing is uploaded, nothing is logged to a server, nothing is cached in a third-party account. Useful when the data is under an NDA, under GDPR, or just under your collar.
+
+## Not a Replacement — a Complement
+
+PondPilot doesn't replace your warehouse or your BI tool. It's the tool you reach for when you need an answer in the next ten minutes and opening a ticket is the slowest path to it.
+
+## Open PondPilot
+
+[app.pondpilot.io](https://app.pondpilot.io) — browser SQL for analysts, no signup.
+
+---
+
+## Related
+
+- [Data Analysis for Startups](/audience/data-analysis-for-startups/)
+- [Browser SQL Analytics](/use-cases/browser-sql-analytics/)
+- [Excel Alternative for Data Analysis](/alternatives/excel-alternative-for-data-analysis/)

--- a/pseo/sql-tool-for-marketers.md
+++ b/pseo/sql-tool-for-marketers.md
@@ -1,0 +1,105 @@
+---
+layout: page
+title: "SQL Tool for Marketers — Campaign CSVs and UTM Analysis in the Browser"
+description: "Analyze campaign exports, channel attribution, and UTM performance without waiting on analytics. PondPilot runs SQL on your CSVs in the browser."
+permalink: /audience/sql-tool-for-marketers/
+---
+
+
+You have a Google Ads export, a Meta CSV, a HubSpot contacts file, and a UTM-tagged session pull from GA. The analytics team is three weeks out. The campaign wraps Friday. PondPilot lets you stitch those CSVs together and answer your own questions today, in a browser tab.
+
+## Campaign Exports, Joined
+
+Every ad platform exports CSV. Drop them all into [app.pondpilot.io](https://app.pondpilot.io) and query them as if they were one database:
+
+```sql
+-- Blended CAC by channel across paid platforms
+SELECT
+  channel,
+  SUM(spend) AS total_spend,
+  SUM(conversions) AS total_conversions,
+  ROUND(SUM(spend) / NULLIF(SUM(conversions), 0), 2) AS cac
+FROM (
+  SELECT 'google' AS channel, cost AS spend, conversions FROM 'google_ads.csv'
+  UNION ALL
+  SELECT 'meta',   amount_spent,        results       FROM 'meta_ads.csv'
+  UNION ALL
+  SELECT 'linkedin', total_spent,       leads         FROM 'linkedin_ads.csv'
+)
+GROUP BY channel
+ORDER BY cac;
+```
+
+## UTM Attribution Without a Ticket
+
+Pull a sessions export from GA or your product analytics and do the attribution cut you actually want:
+
+```sql
+SELECT
+  utm_source,
+  utm_medium,
+  utm_campaign,
+  COUNT(DISTINCT session_id) AS sessions,
+  COUNT(DISTINCT CASE WHEN converted THEN user_id END) AS converters,
+  ROUND(
+    100.0 * COUNT(DISTINCT CASE WHEN converted THEN user_id END)
+    / NULLIF(COUNT(DISTINCT user_id), 0),
+    2
+  ) AS conversion_rate
+FROM 'sessions.csv'
+WHERE session_start >= DATE '2024-10-01'
+GROUP BY 1, 2, 3
+ORDER BY sessions DESC;
+```
+
+## First-Touch vs. Last-Touch
+
+Multi-touch attribution is a SQL window function away:
+
+```sql
+WITH ordered AS (
+  SELECT
+    user_id,
+    utm_source,
+    event_ts,
+    ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY event_ts) AS rn_first,
+    ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY event_ts DESC) AS rn_last
+  FROM 'touchpoints.csv'
+)
+SELECT
+  COUNT(*) FILTER (WHERE rn_first = 1 AND utm_source = 'google') AS first_touch_google,
+  COUNT(*) FILTER (WHERE rn_last  = 1 AND utm_source = 'google') AS last_touch_google
+FROM ordered;
+```
+
+## CRM Joins
+
+Join your Meta lead export to a HubSpot contacts CSV and see which ad sets actually produced pipeline — not just form fills:
+
+```sql
+SELECT m.adset_name, COUNT(*) AS leads, SUM(CASE WHEN h.stage = 'SQL' THEN 1 ELSE 0 END) AS sqls
+FROM 'meta_leads.csv' m
+LEFT JOIN 'hubspot_contacts.csv' h ON m.email = h.email
+GROUP BY m.adset_name
+ORDER BY sqls DESC;
+```
+
+## No Upload, No Vendor Account
+
+Paid-media exports include customer emails and PII. PondPilot processes them locally in the browser — nothing is uploaded, no marketing-SaaS vendor ends up holding a copy.
+
+## SQL Basics Are Enough
+
+GROUP BY is a pivot table. WHERE is a filter. JOIN is a VLOOKUP that actually works. The autocomplete shows you what's available as you type.
+
+## Start Analyzing
+
+[Open PondPilot](https://app.pondpilot.io) — marketing SQL, no ticket required.
+
+---
+
+## Related
+
+- [SQL Tool for Product Managers](/audience/sql-tool-for-product-managers/)
+- [Excel Alternative for Data Analysis](/alternatives/excel-alternative-for-data-analysis/)
+- [Browser SQL Analytics](/use-cases/browser-sql-analytics/)

--- a/pseo/sqlite-viewer-online.md
+++ b/pseo/sqlite-viewer-online.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: "SQLite Viewer Online — Open .sqlite and .db Files in Your Browser"
+description: "Open SQLite databases in your browser via DuckDB's native SQLite attach. Browse tables, run SQL, export results. No uploads."
+permalink: /formats/sqlite-viewer-online/
+---
+
+
+Got a `.sqlite` or `.db` file and need to poke at it? PondPilot opens SQLite databases directly in the browser — no installer, no `sqlite3` CLI, no uploading your file somewhere.
+
+## How It Works
+
+1. Open [app.pondpilot.io](https://app.pondpilot.io)
+2. Drop in your `.sqlite`, `.sqlite3`, or `.db` file
+3. Browse tables in the schema panel
+4. Run SQL against them
+
+DuckDB has a native SQLite extension — it attaches the SQLite file directly and exposes every table as if it were a DuckDB table. No conversion step, no import. It just reads the file in place.
+
+## Browse Tables and Schemas
+
+The schema panel shows every table, view, column, and type. Useful when you receive a SQLite file and have no idea what's inside:
+
+```sql
+SHOW TABLES;
+DESCRIBE my_table;
+SELECT * FROM my_table LIMIT 10;
+```
+
+## DuckDB SQL Against SQLite Data
+
+Once attached, you get DuckDB's full analytical SQL dialect on top of the SQLite data — window functions, CTEs, JSON functions, list operations, the works. It's strictly a superset of what you could do with the `sqlite3` shell.
+
+```sql
+SELECT
+  strftime(created_at, '%Y-%m') AS month,
+  COUNT(*) AS events,
+  COUNT(DISTINCT user_id) AS users
+FROM events
+GROUP BY 1
+ORDER BY 1;
+```
+
+## Export to Anything
+
+Pull data out of SQLite and export to CSV, Parquet, JSON, or Excel. Handy when migrating a legacy SQLite database into a modern analytics stack.
+
+## Privacy
+
+Application databases, mobile app exports, and desktop app data all live in SQLite files — usually with PII, credentials, or private content inside. PondPilot processes everything in-browser. The file is never uploaded.
+
+## Handles Real-World Files
+
+DuckDB's SQLite reader is robust. It handles WAL mode databases, large files, and unusual type affinities without requiring you to touch the file first.
+
+## Get Started
+
+Visit [app.pondpilot.io](https://app.pondpilot.io) and drop in your SQLite file.
+
+---
+
+## Related
+
+- [Data Format Converter](/formats/data-format-converter-browser/)
+- [No-Cloud SQL Editor](/privacy/no-cloud-sql-editor/)
+- [Private Data Exploration](/privacy/private-data-exploration/)

--- a/pseo/superset-alternative.md
+++ b/pseo/superset-alternative.md
@@ -1,0 +1,60 @@
+---
+layout: page
+title: "Apache Superset Alternative — Zero-Infra SQL in the Browser"
+description: "A lightweight Apache Superset alternative for ad-hoc SQL. PondPilot runs entirely in your browser — no Python, no database, no deployment."
+permalink: /alternatives/superset-alternative/
+---
+
+
+[Apache Superset](https://superset.apache.org/) is a serious BI platform — rich charts, dashboards, SQL Lab, role-based access, a metadata database. It's also a nontrivial thing to run: Python, Celery, Redis, a metadata DB, a web server. If you don't need the dashboard layer, that's a lot to stand up. PondPilot offers the "query some files with SQL" piece without any of the infrastructure.
+
+## PondPilot vs Superset
+
+| | Superset | PondPilot |
+|---|---|---|
+| **Deployment** | Python app + metadata DB + worker/broker | None — open a URL |
+| **Engine** | Pushes SQL to connected databases | DuckDB-WASM in the browser |
+| **Data source** | Live DBs (Postgres, Snowflake, Trino, etc.) | Local CSV, Parquet, JSON, DuckDB |
+| **Accounts** | Required (admin, roles, permissions) | None |
+| **Charts & dashboards** | Yes, extensive | No |
+| **Privacy** | Server sees queries; data stays in DB | Everything stays in the browser |
+
+## When PondPilot Fits
+
+**Ad-hoc exploration of files:** Someone hands you a Parquet dump. You don't want to onboard it into Superset to ask three questions about it.
+
+**No infra budget:** You don't have a box to run Superset on, and you don't want one.
+
+**Privacy by default:** Queries run locally. No server log, no shared cluster, nothing to audit.
+
+**Personal analytics:** Your own exports, your own files, your own machine.
+
+## When Superset Fits
+
+**Organization-wide BI:** Superset is designed to serve many users with permissions, dashboards, and alerting. PondPilot serves exactly one user: you.
+
+**Live warehouse connectivity:** Superset speaks SQLAlchemy and connects to nearly any production DB. PondPilot works against files, not live connections.
+
+**Visualization:** Superset's chart library is a core feature. PondPilot shows a results grid; visualization happens elsewhere.
+
+**Governed, reusable datasets:** Superset's semantic layer and saved datasets are built for reuse. PondPilot's state is your browser tab.
+
+## What PondPilot Isn't
+
+PondPilot isn't a BI platform, a dashboard tool, or a replacement for your data team's analytics stack. It's a SQL editor on top of DuckDB-WASM with file loading and result export. The intent is to make the "I just want to SQL this CSV" case trivial.
+
+## A Practical Combination
+
+Plenty of analysts use Superset for curated team dashboards and something lighter for raw file exploration before the data makes it into the warehouse. PondPilot is a fine fit for that upstream, messy-files step.
+
+## Try PondPilot
+
+[Open PondPilot](https://app.pondpilot.io) — no Docker, no Python, no signup.
+
+---
+
+## Related
+
+- [Mode Analytics Alternative](/alternatives/mode-analytics-alternative/)
+- [Datasette Alternative](/alternatives/datasette-alternative/)
+- [Jupyter Notebook Alternative for SQL](/alternatives/jupyter-notebook-alternative-for-sql/)

--- a/pseo/survey-data-analysis.md
+++ b/pseo/survey-data-analysis.md
@@ -1,0 +1,70 @@
+---
+layout: page
+title: "Survey Data Analysis — Cross-Tabs and Response Counts in SQL"
+description: "Analyze survey CSV and SPSS exports locally with SQL. Quick response counts, cross-tabs, and filtering in your browser."
+permalink: /use-cases/survey-data-analysis/
+---
+
+
+Survey exports come out of Qualtrics, SurveyMonkey, Google Forms, Typeform, and a dozen academic tools — usually as CSV, sometimes as SPSS `.sav`. PondPilot lets you query any of them with SQL, locally, without uploading respondent data to another vendor.
+
+## Quick Response Counts
+
+The first question after fielding a survey is always the same: how did people actually answer? SQL makes that fast:
+
+```sql
+SELECT
+  q3_satisfaction,
+  COUNT(*) as responses,
+  ROUND(100.0 * COUNT(*) / SUM(COUNT(*)) OVER (), 1) as pct
+FROM survey_responses.csv
+WHERE completed = true
+GROUP BY q3_satisfaction
+ORDER BY q3_satisfaction;
+```
+
+Drop the file into [PondPilot](https://app.pondpilot.io), run the query, get your distribution in seconds.
+
+## Cross-Tabs Without SPSS
+
+A cross-tab is just a `GROUP BY` with a pivot. DuckDB has `PIVOT` built in:
+
+```sql
+PIVOT survey_responses.csv
+ON region
+USING COUNT(*)
+GROUP BY q3_satisfaction
+ORDER BY q3_satisfaction;
+```
+
+Satisfaction by region, with counts filled in. No macros, no syntax file, no point-and-click wizard.
+
+## SPSS `.sav` Files
+
+If your survey platform or collaborator hands you an SPSS `.sav` export, the DuckDB [read_stat](https://github.com/mettekou/duckdb-read-stat) community extension reads it directly — including variable labels and value labels. Useful when the raw numeric codes don't tell you which response option they map to.
+
+Also handy for inheriting legacy academic datasets where the codebook lives inside the `.sav` itself.
+
+## Filter, Segment, Compare
+
+Once the data's loaded, the usual survey questions are one query away: completion rate by segment, drop-off by question, Net Promoter split, weighted averages, open-text filtering with `ILIKE`. No server, no API quota, no per-seat license.
+
+## Privacy Matters for Surveys
+
+Even "anonymous" surveys often carry enough demographic detail to re-identify small subgroups. Employee surveys, patient-experience surveys, and student surveys are particularly sensitive. Keeping the raw respondent file on your workstation — instead of uploading it to a third-party analytics tool — keeps that risk where you can control it.
+
+## Export Clean Results
+
+Once you've computed the cross-tab or summary you need, export the result as CSV to drop into a report or slide. The raw respondent file stays on your machine; only the aggregated output moves.
+
+## Start Analyzing
+
+[Open PondPilot](https://app.pondpilot.io) and drop in your survey export. Free, open source, no signup.
+
+---
+
+## Related
+
+- [Analyze CSV in Browser](/use-cases/analyze-csv-in-browser/)
+- [Private Data Exploration](/privacy/private-data-exploration/)
+- [Explore JSON Data Locally](/use-cases/explore-json-data-locally/)

--- a/pseo/terminal-sql-client.md
+++ b/pseo/terminal-sql-client.md
@@ -1,0 +1,58 @@
+---
+layout: page
+title: "Terminal SQL Client — Query DuckDB From Your Shell"
+description: "Quack is a terminal SQL client for DuckDB with vim-style editing, schema explorer, and a results browser. No GUI, no browser, no accounts."
+permalink: /tools/terminal-sql-client/
+---
+
+
+If your workflow lives in tmux and a keyboard, a browser-based SQL tool is friction. Quack is a terminal SQL client — a lazygit-style TUI for DuckDB that keeps you in the shell where everything else already runs.
+
+## What Quack Is
+
+Quack is a keyboard-driven TUI for writing SQL against DuckDB and other databases. You open it like any CLI tool, point it at a database file, and start querying. No Electron window, no local server spawning in the background, no login screen.
+
+```bash
+cargo install quack-sql
+# or
+brew install pondpilot/tap/quack
+```
+
+Then launch it and hit `SPC` for the leader menu. `Ctrl+E` runs your query. `:q` quits. The muscle memory is familiar on purpose.
+
+## Why a Terminal Client?
+
+**Fits your existing shell workflow.** Launch Quack in a tmux pane next to your editor, logs, and SSH sessions. Move between them the same way you already do.
+
+**SSH-friendly.** Running analytics on a remote box? Quack works over SSH the same way it works locally. No X forwarding, no port tunnels for a web UI.
+
+**Keyboard-first.** Modal vim-style editing with operator+motion composition, a command palette (`Ctrl+P`), which-key hints, and a schema explorer (`Ctrl+S`) you navigate by arrow keys. Your mouse stays untouched.
+
+**No context switch.** You're already in a terminal. Stay there.
+
+## What You Actually Get
+
+- **Vim-style editing** with syntax highlighting and autocompletion
+- **Schema explorer** — tree view of catalogs, schemas, tables, views, indexes, functions
+- **Results browser** — paginated, sortable, filterable, with aggregates, sparklines, and export
+- **Multi-database** — DuckDB plus SQLite, PostgreSQL, and MySQL connections
+- **Session persistence** — tabs, editor buffers, and query history restored on relaunch
+- **Command palette** — leader key with which-key hints for 40+ actions, plus snippets
+
+The TUI has three panes you'd expect: schema on the left, editor top-right, results below. `Tab` cycles through them.
+
+## Fits a Scripted Pipeline
+
+Because Quack is a normal CLI binary, it coexists cleanly with the rest of your shell toolkit. Keep ad-hoc exploration interactive in Quack, then drop the final SQL into a `.sql` file your pipeline already runs through `duckdb`, `make`, or a scheduler. Same query, two surfaces.
+
+## Install Quack
+
+Grab a release or build from source at the [Quack GitHub repository](https://github.com/pondpilot/quack). MIT licensed, no telemetry, no account.
+
+---
+
+## Related
+
+- [CLI DuckDB Client](/tools/cli-duckdb-client/)
+- [Open Source SQL Editor](/use-cases/open-source-sql-editor/)
+- [No-Cloud SQL Editor](/privacy/no-cloud-sql-editor/)


### PR DESCRIPTION
## Summary

Expands the programmatic SEO set from 60 to 91 pages. Pages target three overlapping drivers: long-tail search traffic, under-represented sub-products (Sonar and Quack had zero pSEO pages before this), and structural gaps in the existing format/alternatives/audience coverage.

Relies on the `_layouts/default.html` fix from #c90bf88..dd5f865 (main) so `layout: page` pages load `blog.css` — otherwise these would all ship unstyled.

### Breakdown (31 files)

- **/formats/ (8):** csv-to-parquet, csv-to-json, json-to-parquet, parquet-to-json, sqlite-viewer-online, excel-to-csv, arrow-feather-viewer, orc-viewer-online. Closes obvious gaps in the format matrix and adds SQLite via DuckDB's sqlite attach.
- **/tools/ + /use-cases/ for Sonar (3):** data-profiling-tool, column-statistics-tool, exploratory-data-analysis-browser.
- **/tools/ + /alternatives/ for Quack and FlowScope (3):** terminal-sql-client, cli-duckdb-client, dbt-lineage-alternative.
- **/alternatives/ (6):** Metabase, Superset, Hex, Redash, Looker Studio, Observable.
- **/audience/ (6):** data analysts, researchers, accountants, data engineers, compliance analysts, marketers.
- **/privacy/ + /use-cases/ (5):** HIPAA-friendly framing, healthcare data analysis, log analysis, survey data, bank-statement analysis. HIPAA page hedges correctly — no BAA claim, just "we never receive your data".

Each page follows the existing pSEO pattern: 45-75 lines, frontmatter with `layout: page` + `permalink`, concrete SQL example where it fits, Related-links to three adjacent existing pages. Primary CTA points to the right product (Sonar pages → Sonar, Quack pages → Quack, rest → app.pondpilot.io).

### Authoring note

Pages were drafted in parallel by six topic-focused subagents, each given a specific cluster of existing pSEO files to read for tone/structure before writing. Product pages (Sonar, Quack, FlowScope) were instructed to read the actual product `index.html` first so positioning reflects what the products really do, not invented features.

## Test plan

- [x] Local Jekyll build succeeds (`bundle exec jekyll build`)
- [x] Sample pages across every bucket render to `_site/` with `blog.css` preloaded and `body class="blog-page"` applied
- [x] Frontmatter uniform across all 31 files (spot-checked one per cluster)
- [x] Related-links point to real existing permalinks
- [ ] Review a sampling of the prose for voice/claims before merging — especially the HIPAA page and the dbt-lineage-alternative framing
- [ ] Post-merge: confirm GitHub Pages serves the new URLs
- [ ] Post-merge: add new URLs to `sitemap.xml` (should be automatic via jekyll-sitemap)