### PR TITLE
Fix broken internal links to DuckDB tool pages

### DIFF
--- a/pseo/data-format-converter-browser.md
+++ b/pseo/data-format-converter-browser.md
@@ -22,7 +22,7 @@ Looking for a specific conversion? Jump directly:
 
 - **Statistical formats:** [SAS to CSV](/formats/sas-to-csv-converter/) · [SAS to Parquet](/formats/sas-to-parquet-converter/) · [Stata to CSV](/formats/stata-to-csv-converter/) · [SPSS to CSV](/formats/spss-to-csv-converter/)
 - **Common formats:** [Excel to Parquet](/formats/excel-to-parquet-converter/) · [JSON to CSV](/formats/json-to-csv-converter/)
-- **Format viewers:** [SAS File Viewer](/formats/sas-file-viewer-free/) · [Parquet Viewer](/tools/duckdb-parquet-viewer/)
+- **Format viewers:** [SAS File Viewer](/formats/sas-file-viewer-free/) · [Parquet Viewer](/duckdb/parquet-viewer/)
 
 ## SQL-Powered Transformation
 

--- a/pseo/duckdb-iceberg-wasm.md
+++ b/pseo/duckdb-iceberg-wasm.md
@@ -54,4 +54,4 @@ Open [app.pondpilot.io](https://app.pondpilot.io) and connect to your Iceberg RE
 
 - [Iceberg Browser Client](/use-cases/iceberg-browser-client/)
 - [Browse Iceberg Tables Online](/use-cases/browse-iceberg-tables-online/)
-- [DuckDB WASM SQL Editor](/tools/duckdb-wasm-sql-editor/)
+- [DuckDB WASM SQL Editor](/duckdb/wasm-sql-editor/)

--- a/pseo/excel-to-parquet-converter.md
+++ b/pseo/excel-to-parquet-converter.md
@@ -60,4 +60,4 @@ Visit [app.pondpilot.io](https://app.pondpilot.io) and convert your Excel file t
 
 - [Data Format Converter](/formats/data-format-converter-browser/)
 - [SAS to Parquet Converter](/formats/sas-to-parquet-converter/)
-- [DuckDB Parquet Viewer](/tools/duckdb-parquet-viewer/)
+- [DuckDB Parquet Viewer](/duckdb/parquet-viewer/)

--- a/pseo/iceberg-data-exploration-tool.md
+++ b/pseo/iceberg-data-exploration-tool.md
@@ -59,4 +59,4 @@ Open [app.pondpilot.io](https://app.pondpilot.io) and explore your Iceberg data.
 
 - [Iceberg Browser Client](/use-cases/iceberg-browser-client/)
 - [Browse Iceberg Tables Online](/use-cases/browse-iceberg-tables-online/)
-- [DuckDB Online Playground](/tools/duckdb-online-playground/)
+- [DuckDB Online Playground](/duckdb/online-playground/)

--- a/pseo/json-to-csv-converter.md
+++ b/pseo/json-to-csv-converter.md
@@ -56,6 +56,6 @@ Open [app.pondpilot.io](https://app.pondpilot.io) and convert your JSON file.
 
 ## Related
 
-- [DuckDB JSON Query](/tools/duckdb-json-query/)
+- [DuckDB JSON Query](/duckdb/json-query/)
 - [Data Format Converter](/formats/data-format-converter-browser/)
 - [Excel to Parquet Converter](/formats/excel-to-parquet-converter/)

--- a/pseo/parquet-viewer-online.md
+++ b/pseo/parquet-viewer-online.md
@@ -58,6 +58,6 @@ Visit [app.pondpilot.io](https://app.pondpilot.io) and open a Parquet file.
 
 ## Related
 
-- [DuckDB Parquet Viewer](/tools/duckdb-parquet-viewer/)
+- [DuckDB Parquet Viewer](/duckdb/parquet-viewer/)
 - [Excel to Parquet Converter](/formats/excel-to-parquet-converter/)
 - [Data Format Converter](/formats/data-format-converter-browser/)


### PR DESCRIPTION
Six pSEO "Related" sections linked to `/tools/duckdb-*`, which 404. Repointed them to the real `/duckdb/*` pages.

Fixes 5 dead URLs (parquet-viewer, wasm-sql-editor, online-playground, json-query) and stops wasting crawl on them.