### PR TITLE
Deepen DB Fiddle + DuckDB playground pages (honesty + FAQ)

### DIFF
--- a/pseo/db-fiddle-alternative.md
+++ b/pseo/db-fiddle-alternative.md
@@ -74,3 +74,44 @@ Yes — PondPilot is free and open source, with no rate limits and no signup.
 - [SQL Playground No Signup](/use-cases/sql-playground-no-signup/)
 - [Datasette Alternative](/alternatives/datasette-alternative/)
 - [DuckDB Online Playground](/duckdb/online-playground/)
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Is PondPilot a drop-in replacement for DB Fiddle?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Not quite — they solve different problems. DB Fiddle reproduces SQL on MySQL, PostgreSQL, or SQLite and gives you a shareable public link. PondPilot runs DuckDB in your browser against your own files, with nothing sent to a server."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I query my own files?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Drop a CSV, Parquet, JSON, or DuckDB file and query it right away — no CREATE TABLE or INSERT. DB Fiddle has no file support; you define the schema and insert rows by hand."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does my data get uploaded anywhere?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. PondPilot runs DuckDB compiled to WebAssembly in your browser, so queries run locally and your data never leaves the tab. DB Fiddle runs your queries on a shared server."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is it free?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — PondPilot is free and open source, with no rate limits and no signup."
+      }
+    }
+  ]
+}
+</script>

--- a/pseo/db-fiddle-alternative.md
+++ b/pseo/db-fiddle-alternative.md
@@ -45,6 +45,24 @@ Need a SQL fiddle in your documentation? [PondPilot Widget](https://widget.pondp
 
 DB Fiddle stores your queries on their servers and assigns them public URLs. PondPilot stores nothing — queries exist only in your browser tab.
 
+## When DB Fiddle is the better choice
+
+DB Fiddle is the right tool when you need to reproduce something on a specific MySQL, PostgreSQL, or SQLite version and share a public link in a bug report or forum thread. That's what it's built for, and the shareable URL is the point. PondPilot runs DuckDB, not those engines, and keeps everything in your browser, so there's no public link to hand out. If you need engine-specific behavior or a shareable permalink, use DB Fiddle. If you want to query your own files with modern analytical SQL and keep the data private, PondPilot is the better fit.
+
+## FAQ
+
+**Is PondPilot a drop-in replacement for DB Fiddle?**
+Not quite — they solve different problems. DB Fiddle reproduces SQL on MySQL, PostgreSQL, or SQLite and gives you a shareable public link. PondPilot runs DuckDB in your browser against your own files, with nothing sent to a server.
+
+**Can I query my own files?**
+Yes. Drop a CSV, Parquet, JSON, or DuckDB file and query it right away — no CREATE TABLE or INSERT. DB Fiddle has no file support; you define the schema and insert rows by hand.
+
+**Does my data get uploaded anywhere?**
+No. PondPilot runs DuckDB compiled to WebAssembly in your browser, so queries run locally and your data never leaves the tab. DB Fiddle runs your queries on a shared server.
+
+**Is it free?**
+Yes — PondPilot is free and open source, with no rate limits and no signup.
+
 ## Try It
 
 [Open PondPilot](https://app.pondpilot.io) — a better SQL playground for modern analytics.

--- a/pseo/duckdb-online-playground.md
+++ b/pseo/duckdb-online-playground.md
@@ -50,6 +50,24 @@ DuckDB WASM is not a watered-down version. It's the same analytical engine, comp
 
 PondPilot is free, open source, and requires no signup. There are no query limits, no session timeouts, and no premium tier. Use it as much as you want.
 
+## When the DuckDB CLI is the better choice
+
+For scripting, scheduled jobs, or files too large to sit comfortably in a browser tab, the native DuckDB CLI or Python client is the right tool — it's built for automation and has no browser memory ceiling. PondPilot is for the interactive case: open a tab, point it at a file, and explore, with nothing to install. Plenty of people use both — the CLI in their pipelines, PondPilot when they just want to look at something.
+
+## FAQ
+
+**Do I need to install anything?**
+No. PondPilot runs DuckDB-WASM in your browser — open app.pondpilot.io and you're in a DuckDB SQL editor in seconds, with no install and no signup.
+
+**Is it the real DuckDB?**
+Yes. DuckDB-WASM is the same analytical engine compiled to WebAssembly. Aggregations over millions of rows run in seconds, and Parquet queries use predicate pushdown.
+
+**Can I load my own data?**
+Yes — open your own CSV, Parquet, JSON, or DuckDB files and query them directly, instead of being limited to toy datasets.
+
+**Does my data leave my machine?**
+No. Everything runs locally in your browser tab; there's no server to send data to.
+
 ## Start Playing
 
 [Open PondPilot](https://app.pondpilot.io) and start exploring DuckDB SQL.

--- a/pseo/duckdb-online-playground.md
+++ b/pseo/duckdb-online-playground.md
@@ -79,3 +79,44 @@ No. Everything runs locally in your browser tab; there's no server to send data 
 - [DuckDB Browser Tool](/duckdb/browser-tool/)
 - [SQL Playground No Signup](/use-cases/sql-playground-no-signup/)
 - [DuckDB WASM SQL Editor](/duckdb/wasm-sql-editor/)
+
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Do I need to install anything?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. PondPilot runs DuckDB-WASM in your browser — open app.pondpilot.io and you're in a DuckDB SQL editor in seconds, with no install and no signup."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is it the real DuckDB?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. DuckDB-WASM is the same analytical engine compiled to WebAssembly. Aggregations over millions of rows run in seconds, and Parquet queries use predicate pushdown."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can I load my own data?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — open your own CSV, Parquet, JSON, or DuckDB files and query them directly, instead of being limited to toy datasets."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does my data leave my machine?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. Everything runs locally in your browser tab; there's no server to send data to."
+      }
+    }
+  ]
+}
+</script>


### PR DESCRIPTION
Two pSEO pages that already get demand but under-convert:

- `/alternatives/db-fiddle-alternative/`
- `/duckdb/online-playground/`

Both sit around position 7 with ~3k monthly impressions each in GSC. To push them toward the top and capture AI-answer traffic, each page gets:

1. **"When [the alternative] is the better choice"** — an honest section on when DB Fiddle / the DuckDB CLI genuinely fits better. Honest comparisons add depth and trust and tend to rank better than one-sided pages.
2. **A short FAQ** (4 Q&A) — answer-first blocks that catch long-tail queries and are the format AI Overviews / assistants quote.
3. **FAQPage JSON-LD** — the FAQ marked up as structured data, text matching the visible content exactly. The site had no schema before, so this is inline per-page (no template change) and introduces no conflicts. Note: Google now limits FAQ rich results in the SERP, but the markup still helps machines and AI parse the Q&A.

Every claim was checked against the product (client-side DuckDB-WASM, file support, free/open-source, no signup).

Follow-ups (separate PRs, not here): site-wide schema (Organization / SoftwareApplication / llms.txt); de-orphan interlinking — hub the App-scoped pSEO from `/app`, FlowScope-scoped from `/flowscope`.