### PR TITLE
Site-wide schema: Organization + SoftwareApplication (+ entity-name fix)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 # GitHub Pages Jekyll configuration
-name: PondPilot Blog
-description: News and updates from the PondPilot team
+name: PondPilot
+description: PondPilot is a family of 100% client-side, DuckDB-powered, open-source data tools. Query, embed, and trace your data in the browser — nothing gets uploaded.
 url: "https://pondpilot.io"
 baseurl: ""
 

--- a/_includes/structured-data.html
+++ b/_includes/structured-data.html
@@ -1,0 +1,105 @@
+{% comment %}
+  Site-wide structured data.
+  - Organization (PondPilot) with sameAs to its own profiles + Dark Lake, LLC as parentOrganization.
+  - Per-product SoftwareApplication emitted when a page sets `product:` in front matter (app / flowscope / widget).
+  This is in addition to the WebSite/WebPage JSON-LD that jekyll-seo-tag already emits.
+{% endcomment %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "@id": "https://pondpilot.io/#organization",
+  "name": "PondPilot",
+  "url": "https://pondpilot.io",
+  "logo": "https://pondpilot.io/assets/images/polly.svg",
+  "description": "A family of 100% client-side, DuckDB-powered, open-source data tools. Query, embed, and trace your data in the browser — nothing gets uploaded.",
+  "sameAs": [
+    "https://github.com/pondpilot",
+    "https://www.linkedin.com/company/pondpilot",
+    "https://www.wikidata.org/wiki/Q139949172"
+  ],
+  "parentOrganization": {
+    "@type": "Organization",
+    "name": "Dark Lake, LLC",
+    "url": "https://darklakeside.com",
+    "sameAs": [
+      "https://www.wikidata.org/wiki/Q139948845",
+      "https://www.crunchbase.com/organization/dark-lake"
+    ]
+  }
+}
+</script>
+{% if page.product == "app" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "PondPilot",
+  "url": "https://app.pondpilot.io",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Web",
+  "description": "A 100% client-side SQL data exploration tool powered by DuckDB-WASM. Query CSV, Parquet, JSON, XLSX, DuckDB, Stata, SAS and SPSS files directly in your browser — read-only, with nothing uploaded.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "isAccessibleForFree": true,
+  "license": "https://www.gnu.org/licenses/agpl-3.0.html",
+  "featureList": [
+    "In-browser DuckDB-WASM SQL editor",
+    "Reads CSV, Parquet, JSON, XLSX, DuckDB, Stata, SAS and SPSS files",
+    "Read-only — your data never leaves the browser",
+    "AI SQL assistant (natural language to SQL)",
+    "Charts and data comparison",
+    "Installable PWA with offline support"
+  ],
+  "sameAs": ["https://github.com/pondpilot/pondpilot"],
+  "publisher": { "@id": "https://pondpilot.io/#organization" }
+}
+</script>
+{% elsif page.product == "flowscope" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "FlowScope",
+  "url": "https://flowscope.pondpilot.io",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Web",
+  "description": "A privacy-first SQL lineage engine that runs entirely in the browser. Analyzes SQL to draw column-level lineage across tables, CTEs and columns — nothing is sent to a server.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "isAccessibleForFree": true,
+  "license": "https://www.apache.org/licenses/LICENSE-2.0",
+  "featureList": [
+    "Column-level SQL lineage",
+    "Multi-dialect: PostgreSQL, Snowflake, BigQuery, DuckDB and dbt",
+    "Runs in the browser (Rust compiled to WebAssembly)",
+    "72 lint rules with auto-fix",
+    "CLI for lineage checks in CI",
+    "Librarian AI chat over your lineage"
+  ],
+  "sameAs": ["https://github.com/pondpilot/flowscope"],
+  "publisher": { "@id": "https://pondpilot.io/#organization" }
+}
+</script>
+{% elsif page.product == "widget" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "PondPilot Widget",
+  "url": "https://widget.pondpilot.io",
+  "applicationCategory": "DeveloperApplication",
+  "operatingSystem": "Web",
+  "description": "An embeddable, interactive SQL widget powered by DuckDB-WASM. Turns static SQL code blocks in docs, tutorials and blog posts into runnable, editable snippets — about 22KB, with zero backend.",
+  "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+  "isAccessibleForFree": true,
+  "license": "https://opensource.org/license/mit",
+  "featureList": [
+    "Embeddable interactive SQL that runs in the reader's browser",
+    "Powered by DuckDB compiled to WebAssembly",
+    "About 22KB, with zero backend to host",
+    "Themeable to match your site"
+  ],
+  "sameAs": ["https://github.com/pondpilot/pondpilot-widget"],
+  "publisher": { "@id": "https://pondpilot.io/#organization" }
+}
+</script>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,6 +23,7 @@
         <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap" /></noscript>
         <link rel="icon" href="{{ page.favicon | default: '/assets/images/polly.svg' }}" type="image/svg+xml" />
         {% seo %}
+        {% include structured-data.html %}
         {% if page.widget_page %}{% include widget-head.html %}{% endif %}
     </head>
     <body class="{% if page.layout == 'post' or page.layout == 'page' or page.url contains '/blog/' %}blog-page{% endif %}">

--- a/app/index.html
+++ b/app/index.html
@@ -2,6 +2,7 @@
 layout: default
 title: PondPilot App - SQL Explorer for Your Data
 description: A blazing-fast, lightweight, 100% client-side data exploration tool powered by DuckDB. Query CSV, Parquet, JSON, and DuckDB files directly in your browser.
+product: app
 ---
 
 <section class="hero">

--- a/flowscope/index.html
+++ b/flowscope/index.html
@@ -3,6 +3,7 @@ layout: default
 title: FlowScope - SQL Lineage Visualization
 description: Visualize SQL data lineage and understand how data flows through your queries. See column-level dependencies at a glance.
 favicon: /assets/images/polly-flowscope.svg
+product: flowscope
 ---
 
 <section class="hero flowscope-hero">

--- a/widget/index.html
+++ b/widget/index.html
@@ -4,6 +4,7 @@ title: PondPilot Widget - Interactive SQL Playgrounds
 description: Transform static SQL into interactive DuckDB sessions. Embed in docs, blogs, and workshops. Zero backend, works anywhere.
 favicon: /assets/images/polly-widget.svg
 widget_page: true
+product: widget
 ---
 
 <section class="hero widget-hero">


### PR DESCRIPTION
Adds the structured-data layer the SEO audit flagged as missing (P1-4): the site only had jekyll-seo-tag's auto `WebSite`/`WebPage`/`BlogPosting`, no `Organization` or `SoftwareApplication`, and the entity name was wrong.

**What's in it**
- **Entity-name fix** — `_config.yml` `name` was `PondPilot Blog`, which leaked into `og:site_name` and the auto JSON-LD and muddied "what is PondPilot" for Google's Knowledge Graph and AI answers. Now `PondPilot`, with a real product description. (The visible `<title>` was already "PondPilot" — hardcoded in the layout — so this only corrects the metadata, no title change.)
- **Organization** JSON-LD with `sameAs` → GitHub, LinkedIn, Wikidata, and **Dark Lake, LLC as `parentOrganization`** (Wikidata + Crunchbase). Entity model: PondPilot is the org the site represents; Dark Lake is its legal parent — which also satisfies "legal entity = Dark Lake" for schema.
- **SoftwareApplication** on `/app`, `/flowscope`, `/widget` — free `Offer`, `featureList`, license, and repo link. This is the main lever for dev-tool AI citations ("best browser SQL tool / DuckDB online / Datasette alternative").
- Implemented as one `_includes/structured-data.html` included site-wide from the layout; product pages opt into their SoftwareApplication with a one-line `product:` front-matter flag.

All four JSON-LD blocks were validated (parse + schema types). Additive to the existing auto schema — no conflicts.

**Note on verification:** I couldn't run a local Jekyll build in my environment (bundler version), and there's no PR CI. The Liquid is standard (`include` + `if/elsif`) and JSON is valid, but please confirm the Pages build succeeds after merge and spot-check `/` and `/app/` in the [Rich Results Test](https://search.google.com/test/rich-results).

**Follow-ups (separate):** `/llms.txt` + `/pricing.md` (P1-5, machine-readable AI-agent files); a raster Organization logo (currently the SVG duck); homepage/`/app` FAQPage (P1-6).