### PR TITLE
Add /llms.txt and /pricing.md (AI discoverability)

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,37 @@
+# PondPilot
+
+> PondPilot is a family of 100% client-side, DuckDB-powered, open-source data tools. You query, embed, and trace your data entirely in the browser — nothing is ever uploaded to a server. Built by Dark Lake, LLC.
+
+All three tools run on DuckDB compiled to WebAssembly, so processing happens on the user's own machine. They are free and open source, with no accounts, no per-seat pricing, and no usage limits. The strongest, most repeatable guarantee across the whole family: your data never leaves your device.
+
+## Products
+
+- [PondPilot App](https://app.pondpilot.io): In-browser SQL editor powered by DuckDB-WASM. Query CSV, Parquet, JSON, XLSX, DuckDB, Stata (.dta), SAS (.sas7bdat/.xpt), and SPSS (.sav) files directly from your machine, read-only, with an AI SQL assistant, charts, and data comparison. Opens instantly, no signup; installable as an offline PWA or self-hostable via Docker. License: AGPL-3.0.
+- [FlowScope](https://flowscope.pondpilot.io): Privacy-first SQL lineage engine that runs in the browser (Rust compiled to WebAssembly). Draws column-level lineage across tables, CTEs, and columns; multi-dialect (PostgreSQL, Snowflake, BigQuery, DuckDB, dbt); 72 lint rules with auto-fix; CLI for CI; "Librarian" AI chat over your lineage. License: Apache-2.0.
+- [PondPilot Widget](https://widget.pondpilot.io): Embeddable, interactive SQL snippets powered by DuckDB-WASM. Turns static SQL code blocks in docs and blog posts into runnable, editable snippets in about 22KB, with zero backend. License: MIT.
+
+## Key pages
+
+- [Homepage](https://pondpilot.io/): the family overview ("Meet the Flock").
+- [PondPilot App](https://pondpilot.io/app/): the flagship SQL explorer.
+- [FlowScope](https://pondpilot.io/flowscope/): SQL lineage visualization.
+- [PondPilot Widget](https://pondpilot.io/widget/): embeddable SQL runner.
+- [Pricing](https://pondpilot.io/pricing.md): free and open source, no paid tiers.
+- [Blog](https://pondpilot.io/blog/): release notes and feature deep-dives.
+
+## Comparisons and use cases
+
+- [DB Fiddle alternative](https://pondpilot.io/alternatives/db-fiddle-alternative/)
+- [Datasette alternative](https://pondpilot.io/alternatives/datasette-alternative/)
+- [DuckDB online playground](https://pondpilot.io/duckdb/online-playground/)
+- [Open Stata (.dta) files in the browser](https://pondpilot.io/formats/open-stata-files-in-browser/)
+- [SQL playground, no signup](https://pondpilot.io/use-cases/sql-playground-no-signup/)
+
+## Source and profiles
+
+- [GitHub organization](https://github.com/pondpilot)
+- [PondPilot App repository](https://github.com/pondpilot/pondpilot)
+- [FlowScope repository](https://github.com/pondpilot/flowscope)
+- [PondPilot Widget repository](https://github.com/pondpilot/pondpilot-widget)
+- [LinkedIn](https://www.linkedin.com/company/pondpilot)
+- [Wikidata](https://www.wikidata.org/wiki/Q139949172)

--- a/pricing.md
+++ b/pricing.md
@@ -1,0 +1,29 @@
+# Pricing — PondPilot
+
+PondPilot is **free and open source**. There are no paid tiers, no per-seat pricing, no accounts, and no usage limits. Nothing is gated behind "contact sales." You can use the hosted apps, install them, or self-host — all at no cost.
+
+Because every tool processes data client-side in the browser, there is no server-side account and no billing to speak of.
+
+## PondPilot App
+- Price: Free
+- License: AGPL-3.0
+- Hosted: https://app.pondpilot.io (opens instantly, no signup)
+- Run it yourself: installable as a PWA (offline), or self-host with Docker (`ghcr.io/pondpilot/pondpilot`), or build from source
+- Source: https://github.com/pondpilot/pondpilot
+
+## FlowScope
+- Price: Free
+- License: Apache-2.0 (core engine)
+- Hosted: https://flowscope.pondpilot.io
+- Source: https://github.com/pondpilot/flowscope
+
+## PondPilot Widget
+- Price: Free
+- License: MIT
+- Embed: add a script tag; runs in the reader's browser (~22KB, zero backend)
+- Source: https://github.com/pondpilot/pondpilot-widget
+
+## Notes
+- No paid plans exist today.
+- Operator: Dark Lake, LLC.
+- Questions, issues, and contributions: https://github.com/pondpilot


### PR DESCRIPTION
Adds the two machine-readable files the SEO audit flagged as missing (P1-5), both at the site root:

- **`/llms.txt`** ([llmstxt.org](https://llmstxt.org) format) — a short, parseable map of what PondPilot is, the three tools (App / FlowScope / Widget) with one-line descriptions and licenses, key pages, top comparison/use-case pages, and source + profile links (GitHub, LinkedIn, Wikidata). This is where AI assistants look for a quick, authoritative overview.
- **`/pricing.md`** — plain pricing in a format AI agents can read without rendering JS. States clearly that everything is free and open source (no tiers, no "contact sales"). Agents that compare tools programmatically filter out products with opaque pricing; this prevents that.

Both are static files (no front matter), served as-is. Every `pondpilot.io` link in `llms.txt` was checked and resolves (the one 404 during authoring was `/pricing.md` itself, which this PR adds). robots.txt already allows all crawlers including AI bots, so no change needed there.

Follow-up (optional): link `/llms.txt` and `/pricing.md` from the footer and add them to the sitemap for extra discoverability.